### PR TITLE
Introduce StopMatchingBehavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ kind-test: test create-cluster fv ## Build docker image; start kind cluster; loa
 
 .PHONY: fv
 fv: $(GINKGO) ## Run Sveltos Controller tests using existing cluster
-	cd test/fv; ../../$(GINKGO) -nodes $(NUM_NODES) --label-filter='FV1' --v --trace --randomize-all
+	cd test/fv; ../../$(GINKGO) -nodes $(NUM_NODES) --label-filter='FV' --v --trace --randomize-all
 
 .PHONY: create-cluster
 create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kind cluster designed for development
@@ -224,10 +224,13 @@ delete-cluster: $(KIND) ## Deletes the kind cluster $(CONTROL_CLUSTER_NAME)
 #
 # add this target. It needs to be run only when changing cluster-api version. create-cluster target uses the output of this command which is stored within repo
 # It requires control cluster to exist. So first "make create-control-cluster" then run this target.
+# Once generated, remove
+#      enforce: "{{ .podSecurityStandard.enforce }}"
+#      enforce-version: "latest"
 create-clusterapi-kind-cluster-yaml: $(CLUSTERCTL) 
-	KUBERNETES_VERSION=$(K8S_VERSION) SERVICE_CIDR=["10.225.0.0/16"] POD_CIDR=["10.220.0.0/16"] $(CLUSTERCTL) generate cluster $(WORKLOAD_CLUSTER_NAME) --flavor development \
+	ENABLE_POD_SECURITY_STANDARD="true" KUBERNETES_VERSION=$(K8S_VERSION) SERVICE_CIDR=["10.225.0.0/16"] POD_CIDR=["10.220.0.0/16"] $(CLUSTERCTL) generate cluster $(WORKLOAD_CLUSTER_NAME) --flavor development \
 		--control-plane-machine-count=1 \
-  		--worker-machine-count=1 > $(KIND_CLUSTER_YAML)
+  		--worker-machine-count=2 > $(KIND_CLUSTER_YAML)
 
 create-control-cluster:
 	sed -e "s/K8S_VERSION/$(K8S_VERSION)/g"  test/$(KIND_CONFIG) > test/$(KIND_CONFIG).tmp

--- a/api/v1alpha1/clusterprofile_types.go
+++ b/api/v1alpha1/clusterprofile_types.go
@@ -115,6 +115,18 @@ type HelmChart struct {
 	HelmChartAction HelmChartAction `json:"helmChartAction,omitempty"`
 }
 
+// StopMatchingBehavior indicates what will happen when Cluster stops matching
+// a ClusterProfile. By default, withdrawpolicies, deployed Helm charts and Kubernetes
+// resources will be removed from Cluster. LeavePolicy instead leaves Helm charts
+// and Kubernetes policies in the Cluster.
+type StopMatchingBehavior string
+
+// Define the StopMatchingBehavior constants.
+const (
+	WithdrawPolicies StopMatchingBehavior = "WithdrawPolicies"
+	LeavePolicies    StopMatchingBehavior = "LeavePolicies"
+)
+
 // ClusterProfileSpec defines the desired state of ClusterProfile
 type ClusterProfileSpec struct {
 	// ClusterSelector identifies ClusterAPI clusters to associate to.
@@ -127,9 +139,20 @@ type ClusterProfileSpec struct {
 	// - Continuous means first time a workload cluster matches the ClusterProfile,
 	// features will be deployed in such a cluster. Any subsequent feature configuration
 	// change will be applied into the matching workload clusters.
+	// - DryRun means no change will be propagated to any matching cluster. A report
+	// instead will be generated summarizing what would happen in any matching cluster
+	// because of the changes made to ClusterProfile while in DryRun mode.
 	// +kubebuilder:default:=Continuous
 	// +optional
 	SyncMode SyncMode `json:"syncMode,omitempty"`
+
+	// StopMatchingBehavior indicates what behavior should be when a Cluster stop matching
+	// the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
+	// be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
+	// leave ClusterProfile deployed policies in the Cluster.
+	// +kubebuilder:default:=WithdrawPolicies
+	// +optional
+	StopMatchingBehavior StopMatchingBehavior `json:"stopMatchingBehavior,omitempty"`
 
 	// PolicyRefs references all the ConfigMaps containing kubernetes resources
 	// that need to be deployed in the matching CAPI clusters.

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -116,6 +116,14 @@ spec:
                   - namespace
                   type: object
                 type: array
+              stopMatchingBehavior:
+                default: WithdrawPolicies
+                description: StopMatchingBehavior indicates what behavior should be
+                  when a Cluster stop matching the ClusterProfile. By default all
+                  deployed Helm charts and Kubernetes resources will be withdrawn
+                  from Cluster. Setting StopMatchingBehavior to LeavePolicies will
+                  instead leave ClusterProfile deployed policies in the Cluster.
+                type: string
               syncMode:
                 default: Continuous
                 description: SyncMode specifies how features are synced in a matching
@@ -125,7 +133,11 @@ spec:
                   the matching workload clusters; - Continuous means first time a
                   workload cluster matches the ClusterProfile, features will be deployed
                   in such a cluster. Any subsequent feature configuration change will
-                  be applied into the matching workload clusters.
+                  be applied into the matching workload clusters. - DryRun means no
+                  change will be propagated to any matching cluster. A report instead
+                  will be generated summarizing what would happen in any matching
+                  cluster because of the changes made to ClusterProfile while in DryRun
+                  mode.
                 enum:
                 - OneTime
                 - Continuous

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -129,6 +129,14 @@ spec:
                       - namespace
                       type: object
                     type: array
+                  stopMatchingBehavior:
+                    default: WithdrawPolicies
+                    description: StopMatchingBehavior indicates what behavior should
+                      be when a Cluster stop matching the ClusterProfile. By default
+                      all deployed Helm charts and Kubernetes resources will be withdrawn
+                      from Cluster. Setting StopMatchingBehavior to LeavePolicies
+                      will instead leave ClusterProfile deployed policies in the Cluster.
+                    type: string
                   syncMode:
                     default: Continuous
                     description: SyncMode specifies how features are synced in a matching
@@ -139,6 +147,10 @@ spec:
                       first time a workload cluster matches the ClusterProfile, features
                       will be deployed in such a cluster. Any subsequent feature configuration
                       change will be applied into the matching workload clusters.
+                      - DryRun means no change will be propagated to any matching
+                      cluster. A report instead will be generated summarizing what
+                      would happen in any matching cluster because of the changes
+                      made to ClusterProfile while in DryRun mode.
                     enum:
                     - OneTime
                     - Continuous

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,8 +59,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
             cpu: 500m

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -69,6 +69,8 @@ var (
 	GetPolicyInfo                = getPolicyInfo
 	UndeployStaleResources       = undeployStaleResources
 	GetDeployedGroupVersionKinds = getDeployedGroupVersionKinds
+	CanDelete                    = canDelete
+	HandleResourceDelete         = handleResourceDelete
 
 	ResourcesHash   = resourcesHash
 	GetResourceRefs = getResourceRefs

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ var (
 
 const (
 	defaultReconcilers = 10
-	defaultWorkers     = 10
+	defaultWorkers     = 20
 )
 
 func main() {

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -325,6 +325,14 @@ spec:
                   - namespace
                   type: object
                 type: array
+              stopMatchingBehavior:
+                default: WithdrawPolicies
+                description: StopMatchingBehavior indicates what behavior should be
+                  when a Cluster stop matching the ClusterProfile. By default all
+                  deployed Helm charts and Kubernetes resources will be withdrawn
+                  from Cluster. Setting StopMatchingBehavior to LeavePolicies will
+                  instead leave ClusterProfile deployed policies in the Cluster.
+                type: string
               syncMode:
                 default: Continuous
                 description: SyncMode specifies how features are synced in a matching
@@ -334,7 +342,11 @@ spec:
                   the matching workload clusters; - Continuous means first time a
                   workload cluster matches the ClusterProfile, features will be deployed
                   in such a cluster. Any subsequent feature configuration change will
-                  be applied into the matching workload clusters.
+                  be applied into the matching workload clusters. - DryRun means no
+                  change will be propagated to any matching cluster. A report instead
+                  will be generated summarizing what would happen in any matching
+                  cluster because of the changes made to ClusterProfile while in DryRun
+                  mode.
                 enum:
                 - OneTime
                 - Continuous
@@ -747,6 +759,14 @@ spec:
                       - namespace
                       type: object
                     type: array
+                  stopMatchingBehavior:
+                    default: WithdrawPolicies
+                    description: StopMatchingBehavior indicates what behavior should
+                      be when a Cluster stop matching the ClusterProfile. By default
+                      all deployed Helm charts and Kubernetes resources will be withdrawn
+                      from Cluster. Setting StopMatchingBehavior to LeavePolicies
+                      will instead leave ClusterProfile deployed policies in the Cluster.
+                    type: string
                   syncMode:
                     default: Continuous
                     description: SyncMode specifies how features are synced in a matching
@@ -757,6 +777,10 @@ spec:
                       first time a workload cluster matches the ClusterProfile, features
                       will be deployed in such a cluster. Any subsequent feature configuration
                       change will be applied into the matching workload clusters.
+                      - DryRun means no change will be propagated to any matching
+                      cluster. A report instead will be generated summarizing what
+                      would happen in any matching cluster because of the changes
+                      made to ClusterProfile while in DryRun mode.
                     enum:
                     - OneTime
                     - Continuous

--- a/test/fv/dryrun_test.go
+++ b/test/fv/dryrun_test.go
@@ -116,7 +116,7 @@ var _ = Describe("DryRun", func() {
 				RepositoryURL:    "https://charts.bitnami.com/bitnami",
 				RepositoryName:   "bitnami",
 				ChartName:        "bitnami/mysql",
-				ChartVersion:     "9.3.3",
+				ChartVersion:     "9.4.3",
 				ReleaseName:      "mysql",
 				ReleaseNamespace: "mysql",
 				HelmChartAction:  configv1alpha1.HelmChartActionInstall,
@@ -133,7 +133,7 @@ var _ = Describe("DryRun", func() {
 		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, clusterSummary.Name, configv1alpha1.FeatureResources)
 
 		charts := []configv1alpha1.Chart{
-			{ReleaseName: "mysql", ChartVersion: "9.3.3", Namespace: "mysql"},
+			{ReleaseName: "mysql", ChartVersion: "9.4.3", Namespace: "mysql"},
 		}
 
 		verifyClusterConfiguration(clusterProfile.Name, clusterSummary.Spec.ClusterNamespace,
@@ -173,7 +173,7 @@ var _ = Describe("DryRun", func() {
 				RepositoryURL:    "https://charts.bitnami.com/bitnami",
 				RepositoryName:   "bitnami",
 				ChartName:        "bitnami/mysql",
-				ChartVersion:     "9.3.3",
+				ChartVersion:     "9.4.3",
 				ReleaseName:      "mysql",
 				ReleaseNamespace: "mysql",
 				HelmChartAction:  configv1alpha1.HelmChartActionInstall,
@@ -267,7 +267,7 @@ var _ = Describe("DryRun", func() {
 				RepositoryURL:    "https://charts.bitnami.com/bitnami",
 				RepositoryName:   "bitnami",
 				ChartName:        "bitnami/mysql",
-				ChartVersion:     "9.3.3",
+				ChartVersion:     "9.4.3",
 				ReleaseName:      "mysql",
 				ReleaseNamespace: "mysql",
 				HelmChartAction:  configv1alpha1.HelmChartActionInstall,
@@ -312,7 +312,7 @@ var _ = Describe("DryRun", func() {
 				RepositoryURL:    "https://charts.bitnami.com/bitnami",
 				RepositoryName:   "bitnami",
 				ChartName:        "bitnami/mysql",
-				ChartVersion:     "9.3.3",
+				ChartVersion:     "9.4.3",
 				ReleaseName:      "mysql",
 				ReleaseNamespace: "mysql",
 				HelmChartAction:  configv1alpha1.HelmChartActionInstall,

--- a/test/fv/helm_conflict_test.go
+++ b/test/fv/helm_conflict_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Helm with conflicts", func() {
 		Expect(k8sClient.Update(context.TODO(), currentCluster)).To(Succeed())
 	})
 
-	It("Two ClusterProfiles managing same helm chart on same cluster", Label("FV1"), func() {
+	It("Two ClusterProfiles managing same helm chart on same cluster", Label("FV"), func() {
 		Byf("Create a ClusterProfile matching Cluster %s/%s", kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
 		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
 		clusterProfile.Spec.SyncMode = configv1alpha1.SyncModeContinuous

--- a/test/fv/leave_helm_charts_test.go
+++ b/test/fv/leave_helm_charts_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
+)
+
+const (
+	minio = "minio"
+)
+
+var _ = Describe("Helm", func() {
+	const (
+		namePrefix = "leave-helm-charts-"
+	)
+
+	It("Deploy helm charts. When Cluster stops matching, policies are left on Cluster", Label("FV"), func() {
+		Byf("Create a ClusterProfile matching Cluster %s/%s", kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1alpha1.SyncModeContinuous
+		clusterProfile.Spec.StopMatchingBehavior = configv1alpha1.LeavePolicies
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		verifyClusterSummary(clusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+
+		Byf("Update ClusterProfile %s to deploy helm charts", clusterProfile.Name)
+		currentClusterProfile := &configv1alpha1.ClusterProfile{}
+		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+		currentClusterProfile.Spec.HelmCharts = []configv1alpha1.HelmChart{
+			{
+				RepositoryURL:    "https://charts.bitnami.com/bitnami",
+				RepositoryName:   "bitnami",
+				ChartName:        "bitnami/minio",
+				ChartVersion:     "11.10.13",
+				ReleaseName:      minio,
+				ReleaseNamespace: minio,
+				HelmChartAction:  configv1alpha1.HelmChartActionInstall,
+			},
+		}
+		Expect(k8sClient.Update(context.TODO(), currentClusterProfile)).To(Succeed())
+
+		clusterSummary := verifyClusterSummary(currentClusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+
+		Byf("Getting client to access the workload cluster")
+		workloadClient, err := getKindWorkloadClusterKubeconfig()
+		Expect(err).To(BeNil())
+		Expect(workloadClient).ToNot(BeNil())
+
+		Byf("Verifying Minio deployment is created in the workload cluster")
+		Eventually(func() error {
+			depl := &appsv1.Deployment{}
+			return workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: "minio", Name: "minio"}, depl)
+		}, timeout, pollingInterval).Should(BeNil())
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, clusterSummary.Name, configv1alpha1.FeatureHelm)
+
+		charts := []configv1alpha1.Chart{
+			{ReleaseName: minio, ChartVersion: "11.10.13", Namespace: minio},
+		}
+
+		verifyClusterConfiguration(clusterProfile.Name, clusterSummary.Spec.ClusterNamespace,
+			clusterSummary.Spec.ClusterName, configv1alpha1.FeatureHelm, nil, charts)
+
+		Byf("Changing clusterprofile ClusterSelector so Cluster is not a match anymore")
+		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+		currentClusterProfile.Spec.ClusterSelector = configv1alpha1.Selector(fmt.Sprintf("%s=%s", key, value+randomString()))
+		Expect(k8sClient.Update(context.TODO(), currentClusterProfile)).To(Succeed())
+
+		Byf("Verifying ClusterSummary is gone")
+		Eventually(func() bool {
+			_, err = getClusterSummary(context.TODO(),
+				clusterProfile.Name, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+			return apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		Byf("Verifying Minio deployment is still present in the workload cluster")
+		depl := &appsv1.Deployment{}
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: minio, Name: minio}, depl)).To(Succeed())
+
+		deleteClusterProfile(clusterProfile)
+	})
+})

--- a/test/fv/leave_policies_test.go
+++ b/test/fv/leave_policies_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
+)
+
+const (
+	nginxDeployment = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80`
+)
+
+var _ = Describe("LeavePolicies", func() {
+	const (
+		namePrefix = "leave-policies-"
+	)
+
+	It("Deploy resources referenced in ResourceRef. When Cluster stops matching, policies are left on Cluster.", Label("FV"), func() {
+		Byf("Create a ClusterProfile matching Cluster %s/%s. StopMatchingBehavior set to LeavePolicies",
+			kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1alpha1.SyncModeContinuous
+		clusterProfile.Spec.StopMatchingBehavior = configv1alpha1.LeavePolicies
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		verifyClusterSummary(clusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+
+		configMapNs := randomString()
+		Byf("Create configMap's namespace %s", configMapNs)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapNs,
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), ns)).To(Succeed())
+
+		deploymentName := "nginx-deployment-" + randomString()
+		deploymentNamespace := "default"
+
+		Byf("Create a configMap with a nginx Deployment")
+		configMap := createConfigMapWithPolicy(configMapNs, namePrefix+randomString(), fmt.Sprintf(nginxDeployment, deploymentName, deploymentNamespace))
+		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
+		currentConfigMap := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, currentConfigMap)).To(Succeed())
+
+		Byf("Update ClusterProfile %s to reference ConfigMap %s/%s", clusterProfile.Name, configMap.Namespace, configMap.Name)
+		currentClusterProfile := &configv1alpha1.ClusterProfile{}
+		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+		currentClusterProfile.Spec.PolicyRefs = []libsveltosv1alpha1.PolicyRef{
+			{
+				Kind:      string(configv1alpha1.ConfigMapReferencedResourceKind),
+				Namespace: configMap.Namespace,
+				Name:      configMap.Name,
+			},
+		}
+		Expect(k8sClient.Update(context.TODO(), currentClusterProfile)).To(Succeed())
+
+		clusterSummary := verifyClusterSummary(currentClusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+
+		Byf("Getting client to access the workload cluster")
+		workloadClient, err := getKindWorkloadClusterKubeconfig()
+		Expect(err).To(BeNil())
+		Expect(workloadClient).ToNot(BeNil())
+
+		Byf("Verifying proper Nginx Deployment is created in the workload cluster")
+		Eventually(func() error {
+			currentDeployment := &appsv1.Deployment{}
+			return workloadClient.Get(context.TODO(), types.NamespacedName{Name: deploymentName, Namespace: deploymentNamespace}, currentDeployment)
+		}, timeout, pollingInterval).Should(BeNil())
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Resources feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, clusterSummary.Name, configv1alpha1.FeatureResources)
+
+		policies := []policy{
+			{kind: "Deployment", name: deploymentName, namespace: deploymentNamespace, group: "apps"},
+		}
+		verifyClusterConfiguration(clusterProfile.Name, clusterSummary.Spec.ClusterNamespace,
+			clusterSummary.Spec.ClusterName, configv1alpha1.FeatureResources, policies, nil)
+
+		Byf("Changing clusterprofile ClusterSelector so Cluster is not a match anymore")
+		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+		currentClusterProfile.Spec.ClusterSelector = configv1alpha1.Selector(fmt.Sprintf("%s=%s", key, value+randomString()))
+		Expect(k8sClient.Update(context.TODO(), currentClusterProfile)).To(Succeed())
+
+		Byf("Verifying ClusterSummary is gone")
+		Eventually(func() bool {
+			_, err = getClusterSummary(context.TODO(),
+				clusterProfile.Name, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+			return apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		Byf("Verifying nginx deployment is still in the workload cluster")
+		currentDeployment := &appsv1.Deployment{}
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Name: deploymentName, Namespace: deploymentNamespace}, currentDeployment)).To(Succeed())
+
+		deleteClusterProfile(clusterProfile)
+	})
+})

--- a/test/sveltos-management-workload.yaml
+++ b/test/sveltos-management-workload.yaml
@@ -155,8 +155,6 @@ spec:
                     apiVersion: pod-security.admission.config.k8s.io/v1beta1
                     kind: PodSecurityConfiguration
                     defaults:
-                      enforce: "{{ .podSecurityStandard.enforce }}"
-                      enforce-version: "latest"
                       audit: "{{ .podSecurityStandard.audit }}"
                       audit-version: "latest"
                       warn: "{{ .podSecurityStandard.warn }}"


### PR DESCRIPTION
When Cluster stops matching a ClusterProfile, by default:
1. all Helm charts deployed in the Cluster by the ClusterProfile instance are withdrawn;
2. all Kubernetes resources deployed in the Cluster by the ClusterProfile instance are withdrawn.

This PR introduce a knob, on ClusterProfile Spec, to make this behavior configurable.
Setting StopMatchingBehavior to:
1. WithdrawPolicies (default behavior) instructs Sveltos to withdraw all Helm charts and Kubernetes resource deployed by the ClusterProfile instance;
2. LeavePolicies instructs Sveltos to leave Helm charts and Kubernetes resources in the cluster.