### PR TITLE
SveltosCluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ deploy-projectsveltos: $(KUSTOMIZE)
 	
 	@echo 'Install libsveltos CRDs'
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/dev/config/crd/bases/lib.projectsveltos.io_debuggingconfigurations.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/dev/config/crd/bases/lib.projectsveltos.io_sveltosclusters.yaml
 
 	# Install projectsveltos controller-manager components
 	@echo 'Install projectsveltos controller-manager components'

--- a/api/v1alpha1/clustersummary_types.go
+++ b/api/v1alpha1/clustersummary_types.go
@@ -136,6 +136,16 @@ type HelmChartSummary struct {
 	ConflictMessage string `json:"conflictMessage,omitempty"`
 }
 
+type ClusterType string
+
+const (
+	// ClusterTypeCapi indicates type is CAPI Cluster
+	ClusterTypeCapi = ClusterType("Capi")
+
+	// ClusterTypeSveltos indicates type is Sveltos Cluster
+	ClusterTypeSveltos = ClusterType("Sveltos")
+)
+
 // ClusterSummarySpec defines the desired state of ClusterSummary
 type ClusterSummarySpec struct {
 	// ClusterNamespace is the namespace of the workload Cluster this
@@ -144,6 +154,9 @@ type ClusterSummarySpec struct {
 
 	// ClusterName is the name of the workload Cluster this ClusterSummary is for.
 	ClusterName string `json:"clusterName"`
+
+	// ClusterType is the type of Cluster
+	ClusterType ClusterType `json:"clusterType"`
 
 	// ClusterProfileSpec represent the configuration that will be applied to
 	// the workload cluster.

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -207,9 +207,13 @@ spec:
                 required:
                 - clusterSelector
                 type: object
+              clusterType:
+                description: ClusterType is the type of Cluster
+                type: string
             required:
             - clusterName
             - clusterNamespace
+            - clusterType
             type: object
           status:
             description: ClusterSummaryStatus defines the observed state of ClusterSummary

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -167,3 +167,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - sveltosclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - sveltosclusters/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -108,7 +108,8 @@ func (m *instance) RegisterClusterSummaryForCharts(clusterSummary *configv1alpha
 		return
 	}
 
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
 	m.chartMux.Lock()
@@ -127,7 +128,8 @@ func (m *instance) RegisterClusterSummaryForCharts(clusterSummary *configv1alpha
 func (m *instance) UnregisterClusterSummaryForChart(clusterSummary *configv1alpha1.ClusterSummary,
 	chart *configv1alpha1.HelmChart) {
 
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	releaseKey := m.GetReleaseKey(chart.ReleaseNamespace, chart.ReleaseName)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
@@ -168,7 +170,8 @@ func (m *instance) RemoveAllRegistrations(clusterSummary *configv1alpha1.Cluster
 // If removeAll is set to true, all registrations are removed. Otherwise only registration for
 // helm releases not referenced anymore are.
 func (m *instance) cleanRegistrations(clusterSummary *configv1alpha1.ClusterSummary, removeAll bool) {
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
 	currentReferencedReleases := make(map[string]bool)
@@ -208,7 +211,8 @@ func (m *instance) cleanRegistrations(clusterSummary *configv1alpha1.ClusterSumm
 func (m *instance) GetManagedHelmReleases(clusterSummary *configv1alpha1.ClusterSummary) []HelmReleaseInfo {
 	info := make([]HelmReleaseInfo, 0)
 
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
 	m.chartMux.Lock()
@@ -231,9 +235,9 @@ func (m *instance) GetManagedHelmReleases(clusterSummary *configv1alpha1.Cluster
 // GetNumberOfRegisteredClusterSummaries returns number of ClusterSummaries currently registered
 // for managing a chart in a given cluster
 func (m *instance) GetNumberOfRegisteredClusterSummaries(clusterNamespace, clusterName string,
-	chart *configv1alpha1.HelmChart) int {
+	clusterType configv1alpha1.ClusterType, chart *configv1alpha1.HelmChart) int {
 
-	clusterKey := m.getClusterKey(clusterNamespace, clusterName)
+	clusterKey := m.getClusterKey(clusterNamespace, clusterName, clusterType)
 	releaseKey := m.GetReleaseKey(chart.ReleaseNamespace, chart.ReleaseName)
 
 	m.chartMux.Lock()
@@ -247,7 +251,8 @@ func (m *instance) GetNumberOfRegisteredClusterSummaries(clusterNamespace, clust
 func (m *instance) CanManageChart(clusterSummary *configv1alpha1.ClusterSummary,
 	chart *configv1alpha1.HelmChart) bool {
 
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	releaseKey := m.GetReleaseKey(chart.ReleaseNamespace, chart.ReleaseName)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
@@ -261,9 +266,9 @@ func (m *instance) CanManageChart(clusterSummary *configv1alpha1.ClusterSummary,
 // helm chart
 // Returns an error if no CLusterSummary is currently managing the chart
 func (m *instance) GetManagerForChart(clusterNamespace, clusterName string,
-	chart *configv1alpha1.HelmChart) (string, error) {
+	clusterType configv1alpha1.ClusterType, chart *configv1alpha1.HelmChart) (string, error) {
 
-	clusterKey := m.getClusterKey(clusterNamespace, clusterName)
+	clusterKey := m.getClusterKey(clusterNamespace, clusterName, clusterType)
 	releaseKey := m.GetReleaseKey(chart.ReleaseNamespace, chart.ReleaseName)
 
 	if _, ok := m.perClusterChartMap[clusterKey]; !ok {
@@ -286,8 +291,10 @@ func (m *instance) GetManagerForChart(clusterNamespace, clusterName string,
 
 // GetRegisteredClusterSummaries returns all ClusterSummary currently registered for at
 // at least one helm chart in the provided CAPI cluster
-func (m *instance) GetRegisteredClusterSummaries(clusterNamespace, clusterName string) []string {
-	clusterKey := m.getClusterKey(clusterNamespace, clusterName)
+func (m *instance) GetRegisteredClusterSummaries(clusterNamespace, clusterName string,
+	clusterType configv1alpha1.ClusterType) []string {
+
+	clusterKey := m.getClusterKey(clusterNamespace, clusterName, clusterType)
 
 	clusterSummaries := make(map[string]bool)
 
@@ -335,8 +342,13 @@ func (m *instance) isCurrentlyManager(clusterKey, releaseKey, clusterSummaryKey 
 }
 
 // getClusterKey returns the Key representing a CAPI Cluster
-func (m *instance) getClusterKey(clusterNamespace, clusterName string) string {
-	return fmt.Sprintf("%s%s%s", clusterNamespace, keySeparator, clusterName)
+func (m *instance) getClusterKey(clusterNamespace, clusterName string, clusterType configv1alpha1.ClusterType) string {
+	prefix := "capi"
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		prefix = "sveltos"
+	}
+
+	return fmt.Sprintf("%s%s%s%s%s", prefix, keySeparator, clusterNamespace, keySeparator, clusterName)
 }
 
 // GetReleaseKey returns the key representing Helm release
@@ -435,7 +447,8 @@ func (m *instance) rebuildRegistrations(ctx context.Context, c client.Client) er
 
 // addManagers walks clusterSummary's status and registers it for each helm chart currently managed
 func (m *instance) addManagers(clusterSummary *configv1alpha1.ClusterSummary) {
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
 	for i := range clusterSummary.Status.HelmReleaseSummaries {
@@ -452,7 +465,8 @@ func (m *instance) addManagers(clusterSummary *configv1alpha1.ClusterSummary) {
 // addNonManagers walks clusterSummary's status and registers it for each helm chart currently not managed
 // (not managed because other ClusterSummary is)
 func (m *instance) addNonManagers(clusterSummary *configv1alpha1.ClusterSummary) {
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Spec.ClusterType)
 	clusterSummaryKey := m.getClusterSummaryKey(clusterSummary.Name)
 
 	for i := range clusterSummary.Status.HelmReleaseSummaries {

--- a/controllers/chartmanager/chartmanager_test.go
+++ b/controllers/chartmanager/chartmanager_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Chart manager", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: randomString(),
 				ClusterName:      upstreamClusterNamePrefix + randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					HelmCharts: []configv1alpha1.HelmChart{
 						{
@@ -250,7 +251,7 @@ var _ = Describe("Chart manager", func() {
 		defer removeSubscriptions(c, tmpClusterSummary)
 
 		csName, err := manager.GetManagerForChart(
-			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, &prometheusChart)
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, &prometheusChart)
 		Expect(err).To(BeNil())
 		Expect(csName).To(Equal(tmpClusterSummary.Name))
 	})
@@ -282,7 +283,7 @@ var _ = Describe("Chart manager", func() {
 			defer removeSubscriptions(c, tmpClusterSummary2)
 
 			registered := manager.GetRegisteredClusterSummaries(
-				clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName)
+				clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType)
 			Expect(len(registered)).To(Equal(2))
 			Expect(registered).To(ContainElement(clusterSummary.Name))
 			Expect(registered).To(ContainElement(tmpClusterSummary1.Name))

--- a/controllers/cluster_utils.go
+++ b/controllers/cluster_utils.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
+)
+
+// getSveltosCluster returns SveltosCluster
+func getSveltosCluster(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string) (*libsveltosv1alpha1.SveltosCluster, error) {
+
+	clusterNamespacedName := types.NamespacedName{
+		Namespace: clusterNamespace,
+		Name:      clusterName,
+	}
+
+	cluster := &libsveltosv1alpha1.SveltosCluster{}
+	if err := c.Get(ctx, clusterNamespacedName, cluster); err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// getCAPICluster returns CAPI Cluster
+func getCAPICluster(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string) (*clusterv1.Cluster, error) {
+
+	clusterNamespacedNamed := types.NamespacedName{
+		Namespace: clusterNamespace,
+		Name:      clusterName,
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := c.Get(ctx, clusterNamespacedNamed, cluster); err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// getCluster returns the cluster associated to ClusterSummary.
+// ClusterSummary can be created for either a CAPI Cluster or a Sveltos Cluster.
+func getCluster(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string, clusterType configv1alpha1.ClusterType) (client.Object, error) {
+
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		return getSveltosCluster(ctx, c, clusterNamespace, clusterName)
+	}
+	return getCAPICluster(ctx, c, clusterNamespace, clusterName)
+}
+
+// isCAPIClusterPaused returns true if CAPI Cluster is paused
+func isCAPIClusterPaused(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string) (bool, error) {
+
+	cluster, err := getCAPICluster(ctx, c, clusterNamespace, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	return cluster.Spec.Paused, nil
+}
+
+// isSveltosClusterPaused returns true if CAPI Cluster is paused
+func isSveltosClusterPaused(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string) (bool, error) {
+
+	cluster, err := getSveltosCluster(ctx, c, clusterNamespace, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	return cluster.Spec.Paused, nil
+}
+
+func isClusterPaused(ctx context.Context, c client.Client,
+	clusterNamespace, clusterName string, clusterType configv1alpha1.ClusterType) (bool, error) {
+
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		return isSveltosClusterPaused(ctx, c, clusterNamespace, clusterName)
+	}
+	return isCAPIClusterPaused(ctx, c, clusterNamespace, clusterName)
+}
+
+func getSecretData(ctx context.Context, c client.Client, clusterNamespace, clusterName string,
+	clusterType configv1alpha1.ClusterType, logger logr.Logger) ([]byte, error) {
+
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		return clusterproxy.GetSveltosSecretData(ctx, logger, c, clusterNamespace, clusterName)
+	}
+	return clusterproxy.GetCAPISecretData(ctx, logger, c, clusterNamespace, clusterName)
+}
+
+func getKubernetesRestConfig(ctx context.Context, c client.Client, clusterNamespace, clusterName string,
+	clusterType configv1alpha1.ClusterType, logger logr.Logger) (*rest.Config, error) {
+
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		return clusterproxy.GetSveltosKubernetesRestConfig(ctx, logger, c, clusterNamespace, clusterName)
+	}
+	return clusterproxy.GetCAPIKubernetesRestConfig(ctx, logger, c, clusterNamespace, clusterName)
+}
+
+func getKubernetesClient(ctx context.Context, c client.Client, s *runtime.Scheme,
+	clusterNamespace, clusterName string, clusterType configv1alpha1.ClusterType, logger logr.Logger) (client.Client, error) {
+
+	if clusterType == configv1alpha1.ClusterTypeSveltos {
+		return clusterproxy.GetSveltosKubernetesClient(ctx, logger, c, s, clusterNamespace, clusterName)
+	}
+	return clusterproxy.GetCAPIKubernetesClient(ctx, logger, c, s, clusterNamespace, clusterName)
+}

--- a/controllers/cluster_utils_test.go
+++ b/controllers/cluster_utils_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
+	"github.com/projectsveltos/sveltos-manager/controllers"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Cluster utils", func() {
+	var namespace string
+	var cluster *clusterv1.Cluster
+	var sveltosCluster *libsveltosv1alpha1.SveltosCluster
+
+	BeforeEach(func() {
+		namespace = "cluster-utils" + randomString()
+
+		cluster = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: namespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+
+		sveltosCluster = &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: namespace,
+			},
+			Spec: libsveltosv1alpha1.SveltosClusterSpec{
+				Paused: true,
+			},
+		}
+	})
+
+	It("isClusterPaused returns true when Spec.Paused is set to true", func() {
+		initObjects := []client.Object{
+			cluster, sveltosCluster,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		paused, err := controllers.IsClusterPaused(context.TODO(), c, cluster.Namespace,
+			cluster.Name, configv1alpha1.ClusterTypeCapi)
+		Expect(err).To(BeNil())
+		Expect(paused).To(BeTrue())
+
+		paused, err = controllers.IsClusterPaused(context.TODO(), c, sveltosCluster.Namespace,
+			sveltosCluster.Name, configv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(paused).To(BeTrue())
+	})
+
+	It("isClusterPaused returns false when Spec.Paused is set to false", func() {
+		cluster.Spec.Paused = false
+		sveltosCluster.Spec.Paused = false
+		initObjects := []client.Object{
+			cluster, sveltosCluster,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		paused, err := controllers.IsClusterPaused(context.TODO(), c, cluster.Namespace,
+			cluster.Name, configv1alpha1.ClusterTypeCapi)
+		Expect(err).To(BeNil())
+		Expect(paused).To(BeFalse())
+
+		paused, err = controllers.IsClusterPaused(context.TODO(), c, sveltosCluster.Namespace,
+			sveltosCluster.Name, configv1alpha1.ClusterTypeSveltos)
+		Expect(err).To(BeNil())
+		Expect(paused).To(BeFalse())
+	})
+
+	It("getSecretData returns kubeconfig data", func() {
+		randomData := []byte(randomString())
+		sveltosSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: sveltosCluster.Namespace,
+				Name:      sveltosCluster.Name + "-sveltos-kubeconfig",
+			},
+			Data: map[string][]byte{
+				"data": randomData,
+			},
+		}
+
+		capiSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name + "-kubeconfig",
+			},
+			Data: map[string][]byte{
+				"data": randomData,
+			},
+		}
+
+		initObjects := []client.Object{
+			sveltosCluster,
+			cluster,
+			&sveltosSecret,
+			&capiSecret,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		data, err := controllers.GetSecretData(context.TODO(), c, cluster.Namespace, cluster.Name,
+			configv1alpha1.ClusterTypeCapi, klogr.New())
+		Expect(err).To(BeNil())
+		Expect(data).To(Equal(randomData))
+
+		data, err = controllers.GetSecretData(context.TODO(), c, sveltosCluster.Namespace, sveltosCluster.Name,
+			configv1alpha1.ClusterTypeSveltos, klogr.New())
+		Expect(err).To(BeNil())
+		Expect(data).To(Equal(randomData))
+	})
+})

--- a/controllers/clusterprofile_predicates_test.go
+++ b/controllers/clusterprofile_predicates_test.go
@@ -26,8 +26,168 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
 )
+
+var _ = Describe("ClusterProfile Predicates: SvelotsClusterPredicates", func() {
+	var logger logr.Logger
+	var cluster *libsveltosv1alpha1.SveltosCluster
+
+	BeforeEach(func() {
+		logger = klogr.New()
+		cluster = &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      upstreamClusterNamePrefix + randomString(),
+				Namespace: "predicates" + randomString(),
+			},
+		}
+	})
+
+	It("Create reprocesses when sveltos Cluster is unpaused", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Spec.Paused = false
+
+		e := event.CreateEvent{
+			Object: cluster,
+		}
+
+		result := clusterPredicate.Create(e)
+		Expect(result).To(BeTrue())
+	})
+	It("Create does not reprocess when sveltos Cluster is paused", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Spec.Paused = true
+		cluster.Annotations = map[string]string{clusterv1.PausedAnnotation: "true"}
+
+		e := event.CreateEvent{
+			Object: cluster,
+		}
+
+		result := clusterPredicate.Create(e)
+		Expect(result).To(BeFalse())
+	})
+	It("Delete does reprocess ", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		e := event.DeleteEvent{
+			Object: cluster,
+		}
+
+		result := clusterPredicate.Delete(e)
+		Expect(result).To(BeTrue())
+	})
+	It("Update reprocesses when sveltos Cluster paused changes from true to false", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Spec.Paused = false
+
+		oldCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+		oldCluster.Spec.Paused = true
+		oldCluster.Annotations = map[string]string{clusterv1.PausedAnnotation: "true"}
+
+		e := event.UpdateEvent{
+			ObjectNew: cluster,
+			ObjectOld: oldCluster,
+		}
+
+		result := clusterPredicate.Update(e)
+		Expect(result).To(BeTrue())
+	})
+	It("Update does not reprocess when sveltos Cluster paused changes from false to true", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Spec.Paused = true
+		cluster.Annotations = map[string]string{clusterv1.PausedAnnotation: "true"}
+		oldCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+		oldCluster.Spec.Paused = false
+
+		e := event.UpdateEvent{
+			ObjectNew: cluster,
+			ObjectOld: oldCluster,
+		}
+
+		result := clusterPredicate.Update(e)
+		Expect(result).To(BeFalse())
+	})
+	It("Update does not reprocess when sveltos Cluster paused has not changed", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Spec.Paused = false
+		oldCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+		oldCluster.Spec.Paused = false
+
+		e := event.UpdateEvent{
+			ObjectNew: cluster,
+			ObjectOld: oldCluster,
+		}
+
+		result := clusterPredicate.Update(e)
+		Expect(result).To(BeFalse())
+	})
+	It("Update reprocesses when sveltos Cluster labels change", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Labels = map[string]string{"department": "eng"}
+
+		oldCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+				Labels:    map[string]string{},
+			},
+		}
+
+		e := event.UpdateEvent{
+			ObjectNew: cluster,
+			ObjectOld: oldCluster,
+		}
+
+		result := clusterPredicate.Update(e)
+		Expect(result).To(BeTrue())
+	})
+	It("Update reprocesses when sveltos Cluster Status Ready changes", func() {
+		clusterPredicate := controllers.SveltosClusterPredicates(logger)
+
+		cluster.Status.Ready = true
+
+		oldCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+				Labels:    map[string]string{},
+			},
+			Status: libsveltosv1alpha1.SveltosClusterStatus{
+				Ready: false,
+			},
+		}
+
+		e := event.UpdateEvent{
+			ObjectNew: cluster,
+			ObjectOld: oldCluster,
+		}
+
+		result := clusterPredicate.Update(e)
+		Expect(result).To(BeTrue())
+	})
+})
 
 var _ = Describe("ClusterProfile Predicates: ClusterPredicates", func() {
 	var logger logr.Logger

--- a/controllers/clusterprofile_transformations_test.go
+++ b/controllers/clusterprofile_transformations_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -30,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
@@ -83,22 +83,22 @@ var _ = Describe("ClusterProfileReconciler map functions", func() {
 		reconciler := &controllers.ClusterProfileReconciler{
 			Client:            c,
 			Scheme:            scheme,
-			ClusterMap:        make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-			ClusterProfileMap: make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-			ClusterProfiles:   make(map[libsveltosv1alpha1.PolicyRef]configv1alpha1.Selector),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfiles:   make(map[corev1.ObjectReference]configv1alpha1.Selector),
 			Mux:               sync.Mutex{},
 		}
 
 		By("Setting ClusterProfileReconciler internal structures")
-		matchingInfo := libsveltosv1alpha1.PolicyRef{Kind: configv1alpha1.ClusterProfileKind, Name: matchingClusterProfile.Name}
+		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ClusterProfileKind, Name: matchingClusterProfile.Name}
 		reconciler.ClusterProfiles[matchingInfo] = matchingClusterProfile.Spec.ClusterSelector
-		nonMatchingInfo := libsveltosv1alpha1.PolicyRef{Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingClusterProfile.Name}
+		nonMatchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingClusterProfile.Name}
 		reconciler.ClusterProfiles[nonMatchingInfo] = nonMatchingClusterProfile.Spec.ClusterSelector
 
 		// ClusterMap contains, per ClusterName, list of ClusterProfiles matching it.
 		clusterProfileSet := &libsveltosset.Set{}
 		clusterProfileSet.Insert(&matchingInfo)
-		clusterInfo := libsveltosv1alpha1.PolicyRef{Kind: "Cluster", Namespace: cluster.Namespace, Name: cluster.Name}
+		clusterInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: cluster.Kind, Namespace: cluster.Namespace, Name: cluster.Name}
 		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
 
 		// ClusterProfileMap contains, per ClusterProfile, list of matched Clusters.

--- a/controllers/clustersummary_controller_test.go
+++ b/controllers/clustersummary_controller_test.go
@@ -76,7 +76,7 @@ var _ = Describe("ClustersummaryController", func() {
 			},
 		}
 
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, clusterName)
+		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, clusterName, false)
 		clusterSummary = &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
@@ -85,6 +85,7 @@ var _ = Describe("ClustersummaryController", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 
@@ -108,7 +109,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -137,7 +139,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -168,7 +171,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -201,7 +205,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -263,7 +268,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -300,7 +306,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -341,7 +348,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          nil,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -364,7 +372,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -409,7 +418,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -467,7 +477,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -529,7 +540,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -588,7 +600,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -646,7 +659,8 @@ var _ = Describe("ClustersummaryController", func() {
 			Client:            c,
 			Scheme:            scheme,
 			Deployer:          deployer,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
@@ -715,6 +729,7 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
 						{
@@ -736,6 +751,7 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
 						{
@@ -778,6 +794,7 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 		configMap := createConfigMapWithPolicy(namespace, randomString(), fmt.Sprintf(editClusterRole, randomString()))
 		By(fmt.Sprintf("Creating %s %s/%s", configMap.Kind, configMap.Namespace, configMap.Name))
 		Expect(testEnv.Client.Create(context.TODO(), configMap)).To(Succeed())
+		Expect(addTypeInformationToObject(scheme, configMap)).To(Succeed())
 
 		By(fmt.Sprintf("Configuring ClusterSummary %s reference %s %s/%s",
 			referencingClusterSummary.Name, configMap.Kind, configMap.Namespace, configMap.Name))
@@ -847,9 +864,11 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 
 		Expect(testEnv.Client.Create(context.TODO(), nonReferencingClusterSummary)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv.Client, nonReferencingClusterSummary)).To(Succeed())
+		addOwnerReference(ctx, testEnv.Client, nonReferencingClusterSummary, clusterProfile)
 
 		Expect(testEnv.Client.Create(context.TODO(), cluster)).To(Succeed())
-		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+		Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
 
 		clusterSummaryName := client.ObjectKey{
 			Name:      referencingClusterSummary.Name,
@@ -865,22 +884,20 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		// Eventual loop so testEnv Cache is synced
-		Eventually(func() bool {
-			clusterSummaryList := controllers.RequeueClusterSummaryForCluster(clusterSummaryReconciler, cluster)
-			result := reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: referencingClusterSummary.Namespace,
-					Name:      referencingClusterSummary.Name,
-				},
+		clusterSummaryList := controllers.RequeueClusterSummaryForCluster(clusterSummaryReconciler, cluster)
+		result := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: referencingClusterSummary.Namespace,
+				Name:      referencingClusterSummary.Name,
+			},
+		}
+		found := false
+		for i := range clusterSummaryList {
+			if clusterSummaryList[i] == result {
+				found = true
 			}
-			for i := range clusterSummaryList {
-				if clusterSummaryList[i] == result {
-					return true
-				}
-			}
-			return false
-		}, timeout, pollingInterval).Should(BeTrue())
+		}
+		Expect(found).To(BeTrue())
 
 		Expect(testEnv.Client.Delete(context.TODO(), ns)).To(Succeed())
 	})

--- a/controllers/clustersummary_deployer_test.go
+++ b/controllers/clustersummary_deployer_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		}
 
 		clusterName = randomString()
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, clusterName)
+		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, clusterName, false)
 		clusterSummary = &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
@@ -60,6 +60,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: namespace,
 				ClusterName:      clusterName,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, namespace, clusterName)

--- a/controllers/clustersummary_transformations_test.go
+++ b/controllers/clustersummary_transformations_test.go
@@ -59,6 +59,7 @@ var _ = Describe("ClustersummaryTransformations map functions", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: namespace,
 				ClusterName:      upstreamClusterNamePrefix + randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
 						{
@@ -78,6 +79,7 @@ var _ = Describe("ClustersummaryTransformations map functions", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: namespace,
 				ClusterName:      upstreamClusterNamePrefix + randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
 						{
@@ -101,22 +103,26 @@ var _ = Describe("ClustersummaryTransformations map functions", func() {
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
 			Scheme:            scheme,
-			ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 			PolicyMux:         sync.Mutex{},
 		}
 
 		set := libsveltosset.Set{}
-		key := libsveltosv1alpha1.PolicyRef{Kind: string(configv1alpha1.ConfigMapReferencedResourceKind), Namespace: configMap.Namespace, Name: configMap.Name}
+		key := corev1.ObjectReference{APIVersion: configMap.APIVersion,
+			Kind: string(configv1alpha1.ConfigMapReferencedResourceKind), Namespace: configMap.Namespace, Name: configMap.Name}
 
-		set.Insert(&libsveltosv1alpha1.PolicyRef{Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary0.Namespace, Name: clusterSummary0.Name})
+		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.Group,
+			Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary0.Namespace, Name: clusterSummary0.Name})
 		reconciler.ReferenceMap[key] = &set
 
 		requests := controllers.RequeueClusterSummaryForReference(reconciler, configMap)
 		Expect(requests).To(HaveLen(1))
 		Expect(requests[0].Name).To(Equal(clusterSummary0.Name))
 
-		set.Insert(&libsveltosv1alpha1.PolicyRef{Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary1.Namespace, Name: clusterSummary1.Name})
+		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.Group,
+			Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary1.Namespace, Name: clusterSummary1.Name})
 		reconciler.ReferenceMap[key] = &set
 
 		requests = controllers.RequeueClusterSummaryForReference(reconciler, configMap)

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -26,13 +26,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	libsveltoscrd "github.com/projectsveltos/libsveltos/lib/crd"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
+	"github.com/projectsveltos/libsveltos/lib/utils"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/api/v1alpha1/index"
 	"github.com/projectsveltos/sveltos-manager/controllers"
@@ -73,12 +76,19 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		By("Starting the manager")
-		if err := testEnv.StartManager(ctx); err != nil {
+		err = testEnv.StartManager(ctx)
+		if err != nil {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}
 	}()
 
 	Expect(index.AddDefaultIndexes(ctx, testEnv.Manager)).To(Succeed())
+
+	var sveltosCRD *unstructured.Unstructured
+	sveltosCRD, err = utils.GetUnstructured(libsveltoscrd.GetClusterCRDYAML())
+	Expect(err).To(BeNil())
+	Expect(testEnv.Create(context.TODO(), sveltosCRD)).To(Succeed())
+	Expect(waitForObject(context.TODO(), testEnv, sveltosCRD)).To(Succeed())
 
 	if synced := testEnv.GetCache().WaitForCacheSync(ctx); !synced {
 		time.Sleep(time.Second)
@@ -97,7 +107,8 @@ func getClusterSummaryReconciler(c client.Client, dep deployer.DeployerInterface
 		Client:            c,
 		Scheme:            scheme,
 		Deployer:          dep,
-		ReferenceMap:      make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+		ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ReferenceMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterSummaryMap: make(map[types.NamespacedName]*libsveltosset.Set),
 		PolicyMux:         sync.Mutex{},
 	}
@@ -107,9 +118,9 @@ func getClusterProfileReconciler(c client.Client) *controllers.ClusterProfileRec
 	return &controllers.ClusterProfileReconciler{
 		Client:            c,
 		Scheme:            scheme,
-		ClusterMap:        make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-		ClusterProfileMap: make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-		ClusterProfiles:   make(map[libsveltosv1alpha1.PolicyRef]configv1alpha1.Selector),
+		ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ClusterProfiles:   make(map[corev1.ObjectReference]configv1alpha1.Selector),
 		Mux:               sync.Mutex{},
 	}
 }

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -101,3 +101,12 @@ var (
 var (
 	GetClusterReportName = getClusterReportName
 )
+
+const (
+	ClusterTypeKey = clusterTypeKey
+)
+
+var (
+	IsClusterPaused = isClusterPaused
+	GetSecretData   = getSecretData
+)

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -72,6 +72,7 @@ var _ = Describe("HandlersHelm", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: clusterNamespace,
 				ClusterName:      randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 	})
@@ -575,6 +576,7 @@ var _ = Describe("Hash methods", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: namespace,
 				ClusterName:      randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					HelmCharts: []configv1alpha1.HelmChart{
 						kyvernoChart,

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/deployer"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
 	"github.com/projectsveltos/sveltos-manager/pkg/scope"
@@ -70,7 +71,7 @@ var _ = Describe("HandlersResource", func() {
 			},
 		}
 
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name)
+		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name, false)
 		clusterSummary = &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
@@ -79,6 +80,7 @@ var _ = Describe("HandlersResource", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 
@@ -111,9 +113,14 @@ var _ = Describe("HandlersResource", func() {
 		Expect(addTypeInformationToObject(testEnv.Scheme(), clusterProfile)).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
+		options := deployer.Options{
+			HandlerOptions: map[string]string{
+				controllers.ClusterTypeKey: string(configv1alpha1.ClusterTypeCapi),
+			},
+		}
 		Eventually(func() error {
 			return controllers.GenericDeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
-				string(configv1alpha1.FeatureResources), klogr.New())
+				string(configv1alpha1.FeatureResources), options, klogr.New())
 		}, timeout, pollingInterval).Should(BeNil())
 
 		// Eventual loop so testEnv Cache is synced
@@ -194,8 +201,13 @@ var _ = Describe("HandlersResource", func() {
 				currentClusterSummary.Status.FeatureSummaries != nil
 		}, timeout, pollingInterval).Should(BeTrue())
 
+		options := deployer.Options{
+			HandlerOptions: map[string]string{
+				controllers.ClusterTypeKey: string(configv1alpha1.ClusterTypeCapi),
+			},
+		}
 		Expect(controllers.GenericUndeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
-			string(configv1alpha1.FeatureResources), klogr.New())).To(Succeed())
+			string(configv1alpha1.FeatureResources), options, klogr.New())).To(Succeed())
 
 		// UnDeployResources finds all policies deployed because of a clusterSummary and deletes those.
 		// Expect role0 and cluster0 to be deleted. role1 should remain as ConfigLabelName is not set on it
@@ -256,6 +268,7 @@ var _ = Describe("Hash methods", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: namespace,
 				ClusterName:      randomString(),
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
 						{Namespace: configMap1.Namespace, Name: configMap1.Name, Kind: string(configv1alpha1.ConfigMapReferencedResourceKind)},

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -124,7 +124,7 @@ var _ = Describe("HandlersUtils", func() {
 			},
 		}
 
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name)
+		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name, false)
 		clusterSummary = &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
@@ -133,6 +133,7 @@ var _ = Describe("HandlersUtils", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 

--- a/controllers/template_instantiation.go
+++ b/controllers/template_instantiation.go
@@ -33,12 +33,15 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/utils"
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 )
 
 type currentClusterObjects struct {
 	Cluster                *clusterv1.Cluster
+	SveltosCluster         *libsveltosv1alpha1.SveltosCluster
 	KubeadmControlPlane    client.Object
 	InfrastructureProvider client.Object
 	SecretRef              client.Object
@@ -103,31 +106,37 @@ func fetchKubeadmControlPlane(ctx context.Context, config *rest.Config, cluster 
 // All fetched objects are in the management cluster.
 // Currently limited to Cluster and Infrastructure Provider
 func fecthClusterObjects(ctx context.Context, config *rest.Config, c client.Client,
-	clusterNamespace, clusterName string, logger logr.Logger) (*currentClusterObjects, error) {
+	clusterNamespace, clusterName string, clusterType configv1alpha1.ClusterType, logger logr.Logger) (*currentClusterObjects, error) {
 
 	logger.V(logs.LogInfo).Info(fmt.Sprintf("Fetch %s/%s", clusterNamespace, clusterName))
-	cluster := &clusterv1.Cluster{}
-	err := c.Get(ctx,
-		types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, cluster)
+
+	genericCluster, err := getCluster(ctx, c, clusterNamespace, clusterName, clusterType)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to fetch cluster %v", err))
 		return nil, err
 	}
 
+	var cluster *clusterv1.Cluster
+	var sveltosCluster *libsveltosv1alpha1.SveltosCluster
 	var provider *unstructured.Unstructured
-	provider, err = fetchInfrastructureProvider(ctx, config, cluster, logger)
-	if err != nil {
-		return nil, err
-	}
-
 	var kubeadmControlPlane *unstructured.Unstructured
-	kubeadmControlPlane, err = fetchKubeadmControlPlane(ctx, config, cluster, logger)
-	if err != nil {
-		return nil, err
-	}
+	if clusterType == configv1alpha1.ClusterTypeCapi {
+		cluster = genericCluster.(*clusterv1.Cluster)
+		provider, err = fetchInfrastructureProvider(ctx, config, cluster, logger)
+		if err != nil {
+			return nil, err
+		}
 
+		kubeadmControlPlane, err = fetchKubeadmControlPlane(ctx, config, cluster, logger)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		sveltosCluster = genericCluster.(*libsveltosv1alpha1.SveltosCluster)
+	}
 	return &currentClusterObjects{
 		Cluster:                cluster,
+		SveltosCluster:         sveltosCluster,
 		InfrastructureProvider: provider,
 		KubeadmControlPlane:    kubeadmControlPlane,
 	}, nil
@@ -147,10 +156,10 @@ func fetchSecretRef(ctx context.Context, c client.Client, secretRef *corev1.Obje
 }
 
 func instantiateTemplateValues(ctx context.Context, config *rest.Config, c client.Client,
-	clusterNamespace, clusterName, requestorName, values string,
+	clusterType configv1alpha1.ClusterType, clusterNamespace, clusterName, requestorName, values string,
 	secretRef *corev1.ObjectReference, logger logr.Logger) (string, error) {
 
-	objects, err := fecthClusterObjects(ctx, config, c, clusterNamespace, clusterName, logger)
+	objects, err := fecthClusterObjects(ctx, config, c, clusterNamespace, clusterName, clusterType, logger)
 	if err != nil {
 		return "", err
 	}

--- a/controllers/template_instantiation_test.go
+++ b/controllers/template_instantiation_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
 )
 
@@ -83,7 +84,7 @@ var _ = Describe("Template instantiation", func() {
       name: "{{ .Cluster.Name }}-test"`
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
-			cluster.Namespace, cluster.Name, randomString(), values, nil, klogr.New())
+			configv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values, nil, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(fmt.Sprintf("%s-test", cluster.Name)))
 	})
@@ -96,7 +97,7 @@ var _ = Describe("Template instantiation", func() {
 	  `
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
-			cluster.Namespace, cluster.Name, randomString(), values, nil, klogr.New())
+			configv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values, nil, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(fmt.Sprintf("%s-test", cluster.Name)))
 		Expect(result).To(ContainSubstring(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0]))
@@ -131,7 +132,7 @@ var _ = Describe("Template instantiation", func() {
     password: "{{ printf "%s" .SecretRef.Data.password | b64dec }}"`
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
-			cluster.Namespace, cluster.Name, randomString(), values,
+			configv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values,
 			&corev1.ObjectReference{Namespace: secret.Namespace, Name: secret.Name}, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(pwd))

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	"github.com/projectsveltos/libsveltos/lib/utils"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
@@ -121,6 +122,9 @@ func setupScheme() (*runtime.Scheme, error) {
 	if err := gatewayapi.AddToScheme(s); err != nil {
 		return nil, err
 	}
+	if err := libsveltosv1alpha1.AddToScheme(s); err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 
@@ -157,7 +161,7 @@ var _ = Describe("getClusterProfileOwner ", func() {
 			},
 		}
 
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name)
+		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, cluster.Name, false)
 		clusterSummary = &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
@@ -166,6 +170,7 @@ var _ = Describe("getClusterProfileOwner ", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, cluster.Namespace, cluster.Name)
@@ -239,6 +244,7 @@ var _ = Describe("getClusterProfileOwner ", func() {
 			Spec: configv1alpha1.ClusterSummarySpec{
 				ClusterNamespace: cluster.Namespace,
 				ClusterName:      cluster.Name,
+				ClusterType:      configv1alpha1.ClusterTypeCapi,
 			},
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.2.2-0.20221206193804-58e84013e1e9
+	github.com/projectsveltos/libsveltos v0.2.2-0.20221213220854-c499edf88ad4
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221206193804-58e84013e1e9 h1:ZOpJd/Ld1F4IDljx6dVt6U9wzchViIZFjlClua6xi6o=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221206193804-58e84013e1e9/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221213220854-c499edf88ad4 h1:L7P6CghzHxJIILhPNzRpIDvTOzksGTn7aJnqjHAqeAM=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221213220854-c499edf88ad4/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	_ "embed"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -119,9 +120,9 @@ func main() {
 	if err = (&controllers.ClusterProfileReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
-		ClusterMap:           make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-		ClusterProfileMap:    make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
-		ClusterProfiles:      make(map[libsveltosv1alpha1.PolicyRef]configv1alpha1.Selector),
+		ClusterMap:           make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ClusterProfileMap:    make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ClusterProfiles:      make(map[corev1.ObjectReference]configv1alpha1.Selector),
 		Mux:                  sync.Mutex{},
 		ConcurrentReconciles: concurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
@@ -133,7 +134,8 @@ func main() {
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
 		Deployer:             d,
-		ReferenceMap:         make(map[libsveltosv1alpha1.PolicyRef]*libsveltosset.Set),
+		ClusterMap:           make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ReferenceMap:         make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterSummaryMap:    make(map[types.NamespacedName]*libsveltosset.Set),
 		PolicyMux:            sync.Mutex{},
 		ConcurrentReconciles: concurrentReconciles,

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -884,9 +884,13 @@ spec:
                 required:
                 - clusterSelector
                 type: object
+              clusterType:
+                description: ClusterType is the type of Cluster
+                type: string
             required:
             - clusterName
             - clusterNamespace
+            - clusterType
             type: object
           status:
             description: ClusterSummaryStatus defines the observed state of ClusterSummary
@@ -1198,6 +1202,22 @@ rules:
   - lib.projectsveltos.io
   resources:
   - debuggingconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - sveltosclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - sveltosclusters/status
   verbs:
   - get
   - list

--- a/test/fv/dryrun_test.go
+++ b/test/fv/dryrun_test.go
@@ -295,10 +295,10 @@ var _ = Describe("DryRun", func() {
 
 		verifyClusterSummary(currentClusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
 
-		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", dryRunClusterSummary.Name)
 		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, dryRunClusterSummary.Name, configv1alpha1.FeatureHelm)
 
-		Byf("Verifying ClusterSummary %s status is set to Deployed for Resource feature", clusterSummary.Name)
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Resource feature", dryRunClusterSummary.Name)
 		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, dryRunClusterSummary.Name, configv1alpha1.FeatureResources)
 
 		Byf("Changing syncMode to DryRun and HelmCharts (some install, one uninstall) for ClusterProfile %s", dryRunClusterProfile.Name)


### PR DESCRIPTION
This PR makes ClusterProfile and ClusterSummary aware of SveltosCluster. SveltosClusters are used to import and let sveltos manage kubernetes clusters non powered by ClusterAPI.