### PR TITLE
ClusterConfiguration/ClusterReport names

### DIFF
--- a/controllers/cluster_utils.go
+++ b/controllers/cluster_utils.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -132,4 +133,19 @@ func getKubernetesClient(ctx context.Context, c client.Client, s *runtime.Scheme
 		return clusterproxy.GetSveltosKubernetesClient(ctx, logger, c, s, clusterNamespace, clusterName)
 	}
 	return clusterproxy.GetCAPIKubernetesClient(ctx, logger, c, s, clusterNamespace, clusterName)
+}
+
+func getClusterType(cluster *corev1.ObjectReference) libsveltosv1alpha1.ClusterType {
+	// TODO: remove this
+	if cluster.APIVersion != libsveltosv1alpha1.GroupVersion.String() &&
+		cluster.APIVersion != clusterv1.GroupVersion.String() {
+
+		panic(1)
+	}
+
+	clusterType := libsveltosv1alpha1.ClusterTypeCapi
+	if cluster.APIVersion == libsveltosv1alpha1.GroupVersion.String() {
+		clusterType = libsveltosv1alpha1.ClusterTypeSveltos
+	}
+	return clusterType
 }

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -387,9 +387,8 @@ func (r *ClusterSummaryReconciler) deployHelm(ctx context.Context, clusterSummar
 func (r *ClusterSummaryReconciler) isClusterPresent(ctx context.Context, clusterSummaryScope *scope.ClusterSummaryScope) (bool, error) {
 	var err error
 	cs := clusterSummaryScope.ClusterSummary
-	if cs.Spec.ClusterType == libsveltosv1alpha1.ClusterTypeSveltos {
-		_, err = getCluster(ctx, r.Client, cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cs.Spec.ClusterType)
-	}
+
+	_, err = getCluster(ctx, r.Client, cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cs.Spec.ClusterType)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -524,7 +523,7 @@ func (r *ClusterSummaryReconciler) updateMaps(ctx context.Context, clusterSummar
 
 	clusterInfo := getKeyFromObject(r.Scheme, clusterObject)
 
-	clusterSummaryInfo := corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.Group,
+	clusterSummaryInfo := corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.String(),
 		Kind: configv1alpha1.ClusterProfileKind, Namespace: clusterSummaryScope.Namespace(),
 		Name: clusterSummaryScope.Name()}
 	r.getClusterMapForEntry(clusterInfo).Insert(&clusterSummaryInfo)
@@ -541,7 +540,7 @@ func (r *ClusterSummaryReconciler) updateMaps(ctx context.Context, clusterSummar
 		tmpResource := referencedResource
 		r.getReferenceMapForEntry(&tmpResource).Insert(
 			&corev1.ObjectReference{
-				APIVersion: configv1alpha1.GroupVersion.Group,
+				APIVersion: configv1alpha1.GroupVersion.String(),
 				Kind:       configv1alpha1.ClusterSummaryKind,
 				Namespace:  clusterSummaryScope.Namespace(),
 				Name:       clusterSummaryScope.Name(),
@@ -554,7 +553,7 @@ func (r *ClusterSummaryReconciler) updateMaps(ctx context.Context, clusterSummar
 		referencedResource := toBeRemoved[i]
 		r.getReferenceMapForEntry(&referencedResource).Erase(
 			&corev1.ObjectReference{
-				APIVersion: configv1alpha1.GroupVersion.Group,
+				APIVersion: configv1alpha1.GroupVersion.String(),
 				Kind:       configv1alpha1.ClusterSummaryKind,
 				Namespace:  clusterSummaryScope.Namespace(),
 				Name:       clusterSummaryScope.Name(),

--- a/controllers/clustersummary_deployer_test.go
+++ b/controllers/clustersummary_deployer_test.go
@@ -258,7 +258,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		Expect(err).To(BeNil())
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), false)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, false)
 		Expect(dep.IsKeyInProgress(key)).To(BeFalse())
 	})
 
@@ -332,7 +332,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		Expect(err.Error()).To(Equal("request is queued"))
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), false)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, false)
 		Expect(dep.IsKeyInProgress(key)).To(BeTrue())
 	})
 
@@ -380,7 +380,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		Expect(err.Error()).To(Equal("request is queued"))
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), false)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, false)
 		Expect(dep.IsKeyInProgress(key)).To(BeTrue())
 	})
 
@@ -418,7 +418,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		Expect(err).To(BeNil())
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), true)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, true)
 		Expect(dep.IsKeyInProgress(key)).To(BeFalse())
 	})
 
@@ -455,7 +455,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		Expect(err.Error()).To(Equal("cleanup request is queued"))
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), true)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, true)
 		Expect(dep.IsKeyInProgress(key)).To(BeTrue())
 	})
 
@@ -476,7 +476,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		dep := fakedeployer.GetClient(context.TODO(), klogr.New(), c)
 		dep.StoreInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), true)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, true)
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
 			{FeatureID: configv1alpha1.FeatureResources, Status: configv1alpha1.FeatureStatusRemoving},
 		}
@@ -507,7 +507,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		dep := fakedeployer.GetClient(context.TODO(), klogr.New(), c)
 		dep.StoreInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummary.Name, string(configv1alpha1.FeatureResources), false)
+			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, false)
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
 			{FeatureID: configv1alpha1.FeatureResources, Status: configv1alpha1.FeatureStatusProvisioning},
 		}

--- a/controllers/clustersummary_transformations_test.go
+++ b/controllers/clustersummary_transformations_test.go
@@ -113,7 +113,7 @@ var _ = Describe("ClustersummaryTransformations map functions", func() {
 		key := corev1.ObjectReference{APIVersion: configMap.APIVersion,
 			Kind: string(configv1alpha1.ConfigMapReferencedResourceKind), Namespace: configMap.Namespace, Name: configMap.Name}
 
-		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.Group,
+		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.String(),
 			Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary0.Namespace, Name: clusterSummary0.Name})
 		reconciler.ReferenceMap[key] = &set
 
@@ -121,7 +121,7 @@ var _ = Describe("ClustersummaryTransformations map functions", func() {
 		Expect(requests).To(HaveLen(1))
 		Expect(requests[0].Name).To(Equal(clusterSummary0.Name))
 
-		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.Group,
+		set.Insert(&corev1.ObjectReference{APIVersion: configv1alpha1.GroupVersion.String(),
 			Kind: configv1alpha1.ClusterSummaryKind, Namespace: clusterSummary1.Namespace, Name: clusterSummary1.Name})
 		reconciler.ReferenceMap[key] = &set
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -99,11 +99,8 @@ var (
 )
 
 var (
-	GetClusterReportName = getClusterReportName
-)
-
-const (
-	ClusterTypeKey = clusterTypeKey
+	GetClusterReportName        = getClusterReportName
+	GetClusterConfigurationName = getClusterConfigurationName
 )
 
 var (

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -86,6 +86,7 @@ type releaseInfo struct {
 
 func deployHelmCharts(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, _ string,
+	clusterType libsveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	// Get ClusterSummary that requested this
@@ -111,6 +112,7 @@ func deployHelmCharts(ctx context.Context, c client.Client,
 
 func undeployHelmCharts(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, _ string,
+	clusterType libsveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	// Get ClusterSummary that requested this
@@ -1272,7 +1274,8 @@ func updateClusterReportWithHelmReports(ctx context.Context, c client.Client,
 		return err
 	}
 
-	clusterReportName := getClusterReportName(clusterProfileOwnerRef.Name, clusterSummary.Spec.ClusterName)
+	clusterReportName := getClusterReportName(clusterProfileOwnerRef.Name,
+		clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType)
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		clusterReport := &configv1alpha1.ClusterReport{}

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -319,7 +319,7 @@ var _ = Describe("HandlersHelm", func() {
 
 		clusterConfiguration := &configv1alpha1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterSummary.Spec.ClusterName,
+				Name:      controllers.GetClusterConfigurationName(clusterSummary.Spec.ClusterName, libsveltosv1alpha1.ClusterTypeCapi),
 				Namespace: clusterSummary.Spec.ClusterNamespace,
 			},
 			Status: configv1alpha1.ClusterConfigurationStatus{
@@ -340,7 +340,10 @@ var _ = Describe("HandlersHelm", func() {
 
 		currentClusterConfiguration := &configv1alpha1.ClusterConfiguration{}
 		Expect(c.Get(context.TODO(),
-			types.NamespacedName{Namespace: clusterConfiguration.Namespace, Name: clusterConfiguration.Name},
+			types.NamespacedName{
+				Namespace: clusterConfiguration.Namespace,
+				Name:      clusterConfiguration.Name,
+			},
 			currentClusterConfiguration)).To(Succeed())
 
 		Expect(currentClusterConfiguration.Status.ClusterProfileResources).ToNot(BeNil())
@@ -404,7 +407,8 @@ var _ = Describe("HandlersHelm", func() {
 
 		clusterReport := &configv1alpha1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      controllers.GetClusterReportName(clusterProfile.Name, clusterSummary.Spec.ClusterName),
+				Name: controllers.GetClusterReportName(clusterProfile.Name, clusterSummary.Spec.ClusterName,
+					clusterSummary.Spec.ClusterType),
 				Namespace: clusterSummary.Spec.ClusterNamespace,
 			},
 			Spec: configv1alpha1.ClusterReportSpec{
@@ -466,7 +470,8 @@ var _ = Describe("HandlersHelm", func() {
 
 		clusterReport := &configv1alpha1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      controllers.GetClusterReportName(clusterProfile.Name, clusterSummary.Spec.ClusterName),
+				Name: controllers.GetClusterReportName(clusterProfile.Name, clusterSummary.Spec.ClusterName,
+					clusterSummary.Spec.ClusterType),
 				Namespace: clusterSummary.Spec.ClusterNamespace,
 			},
 			Spec: configv1alpha1.ClusterReportSpec{

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -38,6 +38,7 @@ import (
 
 func deployResources(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, _ string,
+	clusterType libsveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	featureHandler := getHandlersForFeature(configv1alpha1.FeatureResources)
@@ -111,6 +112,7 @@ func deployResources(ctx context.Context, c client.Client,
 
 func undeployResources(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName, applicant, _ string,
+	clusterType libsveltosv1alpha1.ClusterType,
 	o deployer.Options, logger logr.Logger) error {
 
 	// Get ClusterSummary that requested this
@@ -229,7 +231,8 @@ func updateClusterReportWithResourceReports(ctx context.Context, c client.Client
 		return err
 	}
 
-	clusterReportName := getClusterReportName(clusterProfileOwnerRef.Name, clusterSummary.Spec.ClusterName)
+	clusterReportName := getClusterReportName(clusterProfileOwnerRef.Name,
+		clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType)
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		clusterReport := &configv1alpha1.ClusterReport{}

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -113,14 +113,9 @@ var _ = Describe("HandlersResource", func() {
 		Expect(addTypeInformationToObject(testEnv.Scheme(), clusterProfile)).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
-		options := deployer.Options{
-			HandlerOptions: map[string]string{
-				controllers.ClusterTypeKey: string(libsveltosv1alpha1.ClusterTypeCapi),
-			},
-		}
 		Eventually(func() error {
 			return controllers.GenericDeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
-				string(configv1alpha1.FeatureResources), options, klogr.New())
+				string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, deployer.Options{}, klogr.New())
 		}, timeout, pollingInterval).Should(BeNil())
 
 		// Eventual loop so testEnv Cache is synced
@@ -201,13 +196,8 @@ var _ = Describe("HandlersResource", func() {
 				currentClusterSummary.Status.FeatureSummaries != nil
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		options := deployer.Options{
-			HandlerOptions: map[string]string{
-				controllers.ClusterTypeKey: string(libsveltosv1alpha1.ClusterTypeCapi),
-			},
-		}
 		Expect(controllers.GenericUndeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
-			string(configv1alpha1.FeatureResources), options, klogr.New())).To(Succeed())
+			string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, deployer.Options{}, klogr.New())).To(Succeed())
 
 		// UnDeployResources finds all policies deployed because of a clusterSummary and deletes those.
 		// Expect role0 and cluster0 to be deleted. role1 should remain as ConfigLabelName is not set on it

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -618,7 +618,10 @@ func updateClusterConfiguration(ctx context.Context, c client.Client,
 		// Get ClusterConfiguration for CAPI Cluster
 		clusterConfiguration := &configv1alpha1.ClusterConfiguration{}
 		err := c.Get(ctx,
-			types.NamespacedName{Namespace: clusterSummary.Spec.ClusterNamespace, Name: clusterSummary.Spec.ClusterName},
+			types.NamespacedName{
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+				Name:      getClusterConfigurationName(clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType),
+			},
 			clusterConfiguration)
 		if err != nil {
 			if apierrors.IsNotFound(err) && !clusterSummary.DeletionTimestamp.IsZero() {

--- a/controllers/labels.go
+++ b/controllers/labels.go
@@ -48,9 +48,17 @@ const (
 	// by a ClusterProfile instance for a given cluster
 	ClusterLabelNamespace = "projectsveltos.io/cluster-namespace"
 
-	// clusterLabelName is the label set on ClusterSummary instances created
-	// by a ClusterProfile instance for a given cluster
+	// clusterLabelName is the label set on:
+	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
 	ClusterLabelName = "projectsveltos.io/cluster-name"
+
+	// ClusterTypeLabelName is the label set on:
+	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
+	ClusterTypeLabelName = "projectsveltos.io/cluster-type"
 
 	// PolicyTemplate is the annotation that must be set on a policy when the
 	// policy is a template and needs variable sustitution.

--- a/controllers/suite_helpers_test.go
+++ b/controllers/suite_helpers_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
 )
@@ -252,7 +253,7 @@ func prepareForDeployment(clusterProfile *configv1alpha1.ClusterProfile,
 	clusterConfiguration := &configv1alpha1.ClusterConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
+			Name:      controllers.GetClusterConfigurationName(cluster.Name, libsveltosv1alpha1.ClusterTypeCapi),
 		},
 	}
 
@@ -282,8 +283,9 @@ func prepareForDeployment(clusterProfile *configv1alpha1.ClusterProfile,
 	// So add this logic in a Retry
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		currentClusterConfiguration := &configv1alpha1.ClusterConfiguration{}
+		clusterConfigurationName := controllers.GetClusterConfigurationName(cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 		err := testEnv.Client.Get(context.TODO(),
-			types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, currentClusterConfiguration)
+			types.NamespacedName{Namespace: cluster.Namespace, Name: clusterConfigurationName}, currentClusterConfiguration)
 		if err != nil {
 			return err
 		}
@@ -291,7 +293,7 @@ func prepareForDeployment(clusterProfile *configv1alpha1.ClusterProfile,
 		addOwnerReference(context.TODO(), testEnv.Client, currentClusterConfiguration, currentClusterProfile)
 
 		err = testEnv.Client.Get(context.TODO(),
-			types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, currentClusterConfiguration)
+			types.NamespacedName{Namespace: cluster.Namespace, Name: clusterConfigurationName}, currentClusterConfiguration)
 		if err != nil {
 			return err
 		}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,11 +110,15 @@ func getClusterSummary(ctx context.Context, c client.Client,
 
 // getClusterConfiguration returns the ClusterConfiguration instance for a specific CAPI Cluster
 func getClusterConfiguration(ctx context.Context, c client.Client,
-	clusterNamespace, clusterName string) (*configv1alpha1.ClusterConfiguration, error) {
+	clusterNamespace, clusterConfigurationName string) (*configv1alpha1.ClusterConfiguration, error) {
 
 	clusterConfiguration := &configv1alpha1.ClusterConfiguration{}
 	if err := c.Get(ctx,
-		types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, clusterConfiguration); err != nil {
+		types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterConfigurationName,
+		},
+		clusterConfiguration); err != nil {
 		return nil, err
 	}
 
@@ -295,8 +300,14 @@ func getEntryKey(resourceKind, resourceNamespace, resourceName string) string {
 	return fmt.Sprintf("%s-%s", resourceKind, resourceName)
 }
 
-func getClusterReportName(clusterProfileName, clusterName string) string {
-	return clusterProfileName + "--" + clusterName
+func getClusterReportName(clusterProfileName, clusterName string, clusterType libsveltosv1alpha1.ClusterType) string {
+	// TODO: shorten this value
+	return clusterProfileName + "--" + strings.ToLower(string(clusterType)) + "--" + clusterName
+}
+
+func getClusterConfigurationName(clusterName string, clusterType libsveltosv1alpha1.ClusterType) string {
+	// TODO: shorten this value
+	return strings.ToLower(string(clusterType)) + "--" + clusterName
 }
 
 // getKeyFromObject returns the Key that can be used in the internal reconciler maps.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.2.2-0.20221215200137-0b4989374ab0
+	github.com/projectsveltos/libsveltos v0.2.2-0.20221215235419-fe4742b5248e
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221215200137-0b4989374ab0 h1:2ftu4vTqPpdfjYWNB8wvMXQAMY1gPES38TKa/X8CoU4=
-github.com/projectsveltos/libsveltos v0.2.2-0.20221215200137-0b4989374ab0/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221215235419-fe4742b5248e h1:W9cOMB43rkLWTyY8FTlpMsHMMjWtZz5Obh0RJQ1EfLc=
+github.com/projectsveltos/libsveltos v0.2.2-0.20221215235419-fe4742b5248e/go.mod h1:k9Jjz/3Rjudo/c9Lq/AUSYyUVrKkvcv68ty45Q5SG58=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/test/fv/dryrun_test.go
+++ b/test/fv/dryrun_test.go
@@ -202,7 +202,7 @@ var _ = Describe("DryRun", func() {
 		dryRunClusterSummary := verifyClusterSummary(currentClusterProfile, kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
 
 		By("Verifying ClusterReport for helm reports")
-		clusterReportName := fmt.Sprintf("%s--%s", dryRunClusterProfile.Name, dryRunClusterSummary.Spec.ClusterName)
+		clusterReportName := fmt.Sprintf("%s--capi--%s", dryRunClusterProfile.Name, dryRunClusterSummary.Spec.ClusterName)
 		Eventually(func() error {
 			currentClusterReport := &configv1alpha1.ClusterReport{}
 			err := k8sClient.Get(context.TODO(),

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -266,7 +267,8 @@ func verifyClusterProfileMatches(clusterProfile *configv1alpha1.ClusterProfile) 
 		return err == nil &&
 			len(currentClusterProfile.Status.MatchingClusterRefs) == 1 &&
 			currentClusterProfile.Status.MatchingClusterRefs[0].Namespace == kindWorkloadCluster.Namespace &&
-			currentClusterProfile.Status.MatchingClusterRefs[0].Name == kindWorkloadCluster.Name
+			currentClusterProfile.Status.MatchingClusterRefs[0].Name == kindWorkloadCluster.Name &&
+			currentClusterProfile.Status.MatchingClusterRefs[0].APIVersion == clusterv1.GroupVersion.String()
 	}, timeout, pollingInterval).Should(BeTrue())
 }
 
@@ -336,7 +338,10 @@ func verifyClusterConfiguration(clusterProfileName, clusterNamespace, clusterNam
 	Eventually(func() bool {
 		currentClusterConfiguration := &configv1alpha1.ClusterConfiguration{}
 		err := k8sClient.Get(context.TODO(),
-			types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, currentClusterConfiguration)
+			types.NamespacedName{
+				Namespace: clusterNamespace,
+				Name:      "capi--" + clusterName,
+			}, currentClusterConfiguration)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
Change name so there will be no conflict if a CAPI Cluster and Sveltos Cluster with same name exist in the same namespace.

Pass to any deployer API clusterType to avoid ambiguity in the work requests.