### PR TITLE
Move owner reference logic to libsveltos

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -94,11 +94,6 @@ type (
 )
 
 var (
-	AddOwnerReference    = addOwnerReference
-	RemoveOwnerReference = removeOwnerReference
-)
-
-var (
 	GetClusterReportName        = getClusterReportName
 	GetClusterConfigurationName = getClusterConfigurationName
 )

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -137,9 +137,9 @@ var _ = Describe("HandlersResource", func() {
 				Namespace: namespace,
 				Name:      randomString(),
 				Labels: map[string]string{
-					controllers.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
-					controllers.ReferenceLabelName:      randomString(),
-					controllers.ReferenceLabelNamespace: randomString(),
+					deployer.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+					deployer.ReferenceLabelName:      randomString(),
+					deployer.ReferenceLabelNamespace: randomString(),
 				},
 			},
 		}
@@ -155,9 +155,9 @@ var _ = Describe("HandlersResource", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
 				Labels: map[string]string{
-					controllers.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
-					controllers.ReferenceLabelName:      randomString(),
-					controllers.ReferenceLabelNamespace: randomString(),
+					deployer.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+					deployer.ReferenceLabelName:      randomString(),
+					deployer.ReferenceLabelNamespace: randomString(),
 				},
 			},
 		}

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/deployer"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/utils"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
@@ -188,10 +189,10 @@ func deployContent(ctx context.Context, remoteConfig *rest.Config, c, remoteClie
 		}
 
 		// Get policy hash of referenced policy
-		addLabel(policy, ReferenceLabelKind, referencedObject.GetObjectKind().GroupVersionKind().Kind)
-		addLabel(policy, ReferenceLabelName, referencedObject.GetName())
-		addLabel(policy, ReferenceLabelNamespace, referencedObject.GetNamespace())
-		addAnnotation(policy, PolicyHash, policyHash)
+		addLabel(policy, deployer.ReferenceLabelKind, referencedObject.GetObjectKind().GroupVersionKind().Kind)
+		addLabel(policy, deployer.ReferenceLabelName, referencedObject.GetName())
+		addLabel(policy, deployer.ReferenceLabelNamespace, referencedObject.GetNamespace())
+		addAnnotation(policy, deployer.PolicyHash, policyHash)
 
 		// If policy is namespaced, create namespace if not already existing
 		err = createNamespace(ctx, remoteClient, clusterSummary, policy.GetNamespace())
@@ -209,10 +210,10 @@ func deployContent(ctx context.Context, remoteConfig *rest.Config, c, remoteClie
 
 		var exist bool
 		var currentHash string
-		exist, currentHash, err = validateObjectForUpdate(ctx, dr, policy,
+		exist, currentHash, err = deployer.ValidateObjectForUpdate(ctx, dr, policy,
 			referencedObject.GetObjectKind().GroupVersionKind().Kind, referencedObject.GetNamespace(), referencedObject.GetName())
 		if err != nil {
-			var conflictErr *conflictError
+			var conflictErr *deployer.ConflictError
 			ok := errors.As(err, &conflictErr)
 			// In DryRun mode do not stop here, but report the conflict.
 			if ok && clusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeDryRun {
@@ -223,7 +224,7 @@ func deployContent(ctx context.Context, remoteConfig *rest.Config, c, remoteClie
 			return nil, err
 		}
 
-		addOwnerReference(policy, clusterProfile)
+		deployer.AddOwnerReference(policy, clusterProfile)
 
 		err = updateResource(ctx, dr, clusterSummary, policy, logger)
 		if err != nil {
@@ -477,7 +478,7 @@ func undeployStaleResources(ctx context.Context, remoteConfig *rest.Config, c, r
 			logger.V(logs.LogVerbose).Info("considering %s/%s", r.GetNamespace(), r.GetName())
 			// Verify if this policy was deployed because of a clustersummary (ReferenceLabelName
 			// is present as label in such a case).
-			if !hasLabel(&r, ReferenceLabelName, "") {
+			if !hasLabel(&r, deployer.ReferenceLabelName, "") {
 				continue
 			}
 
@@ -485,7 +486,7 @@ func undeployStaleResources(ctx context.Context, remoteConfig *rest.Config, c, r
 			// If this ClusterSummary is the only OwnerReference and it is not deploying this policy anymore,
 			// policy would be withdrawn
 			if clusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeDryRun {
-				if canDelete(&r, currentPolicies) && isOnlyhOwnerReference(&r, clusterProfile) &&
+				if canDelete(&r, currentPolicies) && deployer.IsOnlyOwnerReference(&r, clusterProfile) &&
 					!isLeavePolicies(clusterSummary, logger) {
 
 					undeployed = append(undeployed, configv1alpha1.ResourceReport{
@@ -499,7 +500,7 @@ func undeployStaleResources(ctx context.Context, remoteConfig *rest.Config, c, r
 			} else {
 				logger.V(logs.LogVerbose).Info("remove owner reference %s/%s", r.GetNamespace(), r.GetName())
 
-				removeOwnerReference(&r, clusterProfile)
+				deployer.RemoveOwnerReference(&r, clusterProfile)
 
 				if len(r.GetOwnerReferences()) != 0 {
 					// Other ClusterSummary are still deploying this very same policy
@@ -526,9 +527,9 @@ func handleResourceDelete(ctx context.Context, remoteClient client.Client, polic
 	// Remove all labels added by Sveltos.
 	if isLeavePolicies(clusterSummary, logger) {
 		labels := policy.GetLabels()
-		delete(labels, ReferenceLabelKind)
-		delete(labels, ReferenceLabelName)
-		delete(labels, ReferenceLabelNamespace)
+		delete(labels, deployer.ReferenceLabelKind)
+		delete(labels, deployer.ReferenceLabelName)
+		delete(labels, deployer.ReferenceLabelNamespace)
 		policy.SetLabels(labels)
 		return remoteClient.Update(ctx, policy)
 	}
@@ -724,7 +725,7 @@ func generateConflictResourceReport(ctx context.Context, dr dynamic.ResourceInte
 		Resource: *resource,
 		Action:   string(configv1alpha1.ConflictResourceAction),
 	}
-	message, err := getOwnerMessage(ctx, dr, resource.Name)
+	message, err := deployer.GetOwnerMessage(ctx, dr, resource.Name)
 	if err == nil {
 		conflictReport.Message = message
 	}

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/deployer"
 	"github.com/projectsveltos/libsveltos/lib/utils"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
@@ -252,10 +253,10 @@ var _ = Describe("HandlersUtils", func() {
 			var policyHash string
 			policyHash, err = controllers.ComputePolicyHash(policy)
 			Expect(err).To(BeNil())
-			controllers.AddLabel(policy, controllers.ReferenceLabelKind, secret.Kind)
-			controllers.AddLabel(policy, controllers.ReferenceLabelName, secret.Name)
-			controllers.AddLabel(policy, controllers.ReferenceLabelNamespace, secret.Namespace)
-			controllers.AddAnnotation(policy, controllers.PolicyHash, policyHash)
+			controllers.AddLabel(policy, deployer.ReferenceLabelKind, secret.Kind)
+			controllers.AddLabel(policy, deployer.ReferenceLabelName, secret.Name)
+			controllers.AddLabel(policy, deployer.ReferenceLabelNamespace, secret.Namespace)
+			controllers.AddAnnotation(policy, deployer.PolicyHash, policyHash)
 			Expect(testEnv.Client.Create(context.TODO(), policy))
 			Expect(waitForObject(ctx, testEnv.Client, policy)).To(Succeed())
 		}
@@ -392,9 +393,9 @@ var _ = Describe("HandlersUtils", func() {
 		clusterRole, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, viewClusterRoleName)))
 		Expect(err).To(BeNil())
 		clusterRole.SetLabels(map[string]string{
-			controllers.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
-			controllers.ReferenceLabelName:      configMap.Name,
-			controllers.ReferenceLabelNamespace: configMap.Namespace,
+			deployer.ReferenceLabelKind:      string(libsveltosv1alpha1.ConfigMapReferencedResourceKind),
+			deployer.ReferenceLabelName:      configMap.Name,
+			deployer.ReferenceLabelNamespace: configMap.Namespace,
 		})
 		clusterRole.SetOwnerReferences([]metav1.OwnerReference{
 			{Kind: configv1alpha1.ClusterProfileKind, Name: clusterProfile.Name,
@@ -452,9 +453,9 @@ var _ = Describe("HandlersUtils", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterRoleName1,
 				Labels: map[string]string{
-					controllers.ReferenceLabelKind:      configMap1.Kind,
-					controllers.ReferenceLabelNamespace: configMap1.Namespace,
-					controllers.ReferenceLabelName:      configMap1.Name,
+					deployer.ReferenceLabelKind:      configMap1.Kind,
+					deployer.ReferenceLabelNamespace: configMap1.Namespace,
+					deployer.ReferenceLabelName:      configMap1.Name,
 				},
 			},
 		}
@@ -465,9 +466,9 @@ var _ = Describe("HandlersUtils", func() {
 				Name:      clusterRoleName2,
 				Namespace: "default",
 				Labels: map[string]string{
-					controllers.ReferenceLabelKind:      configMap2.Kind,
-					controllers.ReferenceLabelNamespace: configMap2.Namespace,
-					controllers.ReferenceLabelName:      configMap2.Name,
+					deployer.ReferenceLabelKind:      configMap2.Kind,
+					deployer.ReferenceLabelNamespace: configMap2.Namespace,
+					deployer.ReferenceLabelName:      configMap2.Name,
 				},
 			},
 		}
@@ -593,10 +594,10 @@ var _ = Describe("HandlersUtils", func() {
 				Namespace: randomString(),
 				Name:      randomString(),
 				Labels: map[string]string{
-					controllers.ReferenceLabelKind:      randomString(),
-					controllers.ReferenceLabelName:      randomString(),
-					controllers.ReferenceLabelNamespace: randomString(),
-					randomKey:                           randomValue,
+					deployer.ReferenceLabelKind:      randomString(),
+					deployer.ReferenceLabelName:      randomString(),
+					deployer.ReferenceLabelNamespace: randomString(),
+					randomKey:                        randomValue,
 				},
 			},
 		}

--- a/controllers/labels.go
+++ b/controllers/labels.go
@@ -29,21 +29,6 @@ const (
 	// by a ClusterProfile instance
 	ClusterProfileLabelName = "projectsveltos.io/cluster-profile-name"
 
-	// ReferenceLabelKind is added to each policy deployed by a ClusterSummary
-	// instance to a CAPI Cluster. Indicates the Kind (ConfigMap or Secret)
-	// containing the policy.
-	ReferenceLabelKind = "projectsveltos.io/reference-kind"
-
-	// ReferenceLabelName is added to each policy deployed by a ClusterSummary
-	// instance to a CAPI Cluster. Indicates the name of the ConfigMap/Secret
-	// containing the policy.
-	ReferenceLabelName = "projectsveltos.io/reference-name"
-
-	// ReferenceLabelNamespace is added to each policy deployed by a ClusterSummary
-	// instance to a CAPI Cluster. Indicates the namespace of the ConfigMap/Secret
-	// containing the policy.
-	ReferenceLabelNamespace = "projectsveltos.io/reference-namespace"
-
 	// clusterLabelNamespace is the label set on ClusterSummary instances created
 	// by a ClusterProfile instance for a given cluster
 	ClusterLabelNamespace = "projectsveltos.io/cluster-namespace"
@@ -63,10 +48,6 @@ const (
 	// PolicyTemplate is the annotation that must be set on a policy when the
 	// policy is a template and needs variable sustitution.
 	PolicyTemplate = "projectsveltos.io/template"
-
-	// PolicyHash is the annotation set on a policy when deployed in a CAPI
-	// cluster.
-	PolicyHash = "projectsveltos.io/hash"
 )
 
 // addLabel adds label to an object

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -18,7 +18,6 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +35,6 @@ import (
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 	configv1alpha1 "github.com/projectsveltos/sveltos-manager/api/v1alpha1"
 	"github.com/projectsveltos/sveltos-manager/controllers"
 )
@@ -261,24 +259,6 @@ var _ = Describe("getClusterProfileOwner ", func() {
 		Expect(err).To(BeNil())
 		Expect(currentClusterSummary).ToNot(BeNil())
 		Expect(currentClusterSummary.Name).To(Equal(clusterSummary.Name))
-	})
-
-	It("addOwnerReference adds an OwnerReference to an object. removeOwnerReference removes it", func() {
-		policy, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
-		Expect(err).To(BeNil())
-		Expect(policy.GetKind()).To(Equal("ClusterRole"))
-
-		Expect(addTypeInformationToObject(testEnv.Scheme(), clusterProfile)).To(Succeed())
-
-		controllers.AddOwnerReference(policy, clusterProfile)
-
-		Expect(policy.GetOwnerReferences()).ToNot(BeNil())
-		Expect(len(policy.GetOwnerReferences())).To(Equal(1))
-		Expect(policy.GetOwnerReferences()[0].Kind).To(Equal(configv1alpha1.ClusterProfileKind))
-		Expect(policy.GetOwnerReferences()[0].Name).To(Equal(clusterProfile.Name))
-
-		controllers.RemoveOwnerReference(policy, clusterProfile)
-		Expect(len(policy.GetOwnerReferences())).To(Equal(0))
 	})
 })
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.3.1-0.20230120222718-143a0c049980
+	github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -790,8 +790,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
-github.com/projectsveltos/libsveltos v0.3.1-0.20230120222718-143a0c049980 h1:FId075g88EC7/OlRAsOSVWombmLH2JsroFvJmrmKOA4=
-github.com/projectsveltos/libsveltos v0.3.1-0.20230120222718-143a0c049980/go.mod h1:smYCt3DQSZpQqsaoM2mJAIP6RAMXcxw5Af0mzkncCs4=
+github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3 h1:6Yv0aM8Qs1ksImBGA3C9XpPLtNXEzHbUznSAUr18N3A=
+github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3/go.mod h1:smYCt3DQSZpQqsaoM2mJAIP6RAMXcxw5Af0mzkncCs4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=


### PR DESCRIPTION
Both ClusterSummary and RoleRequest references ConfigMaps/Secrets and deploys to managed clusters the policies contained in those.

So owner reference logic has been moved to libsveltos