### PR TITLE
Multi tenancy

### DIFF
--- a/api/v1alpha1/clusterprofile_types.go
+++ b/api/v1alpha1/clusterprofile_types.go
@@ -29,6 +29,10 @@ const (
 	ClusterProfileFinalizer = "clusterprofilefinalizer.projectsveltos.io"
 
 	ClusterProfileKind = "ClusterProfile"
+
+	// AdminLabel can be set on ClusterProfile to indicate which admin is creating it.
+	// AdminLabel used along with RoleRequest is Sveltos solution for multi tenancy.
+	AdminLabel = "projectsveltos.io/admin-name"
 )
 
 type DryRunReconciliationError struct{}

--- a/controllers/cluster_utils_test.go
+++ b/controllers/cluster_utils_test.go
@@ -131,12 +131,12 @@ var _ = Describe("Cluster utils", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-		data, err := controllers.GetSecretData(context.TODO(), c, cluster.Namespace, cluster.Name,
+		data, err := controllers.GetSecretData(context.TODO(), c, cluster.Namespace, cluster.Name, "",
 			libsveltosv1alpha1.ClusterTypeCapi, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(data).To(Equal(randomData))
 
-		data, err = controllers.GetSecretData(context.TODO(), c, sveltosCluster.Namespace, sveltosCluster.Name,
+		data, err = controllers.GetSecretData(context.TODO(), c, sveltosCluster.Namespace, sveltosCluster.Name, "",
 			libsveltosv1alpha1.ClusterTypeSveltos, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(data).To(Equal(randomData))

--- a/controllers/clusterprofile_controller.go
+++ b/controllers/clusterprofile_controller.go
@@ -745,7 +745,7 @@ func (r *ClusterProfileReconciler) createClusterSummary(ctx context.Context, clu
 	}
 
 	clusterSummary.Spec.ClusterType = getClusterType(cluster)
-
+	clusterSummary.Labels = clusterProfileScope.ClusterProfile.Labels
 	addLabel(clusterSummary, ClusterProfileLabelName, clusterProfileScope.Name())
 	addLabel(clusterSummary, ClusterLabelNamespace, cluster.Namespace)
 	addLabel(clusterSummary, ClusterLabelName, cluster.Name)
@@ -775,6 +775,12 @@ func (r *ClusterProfileReconciler) updateClusterSummary(ctx context.Context, clu
 
 	clusterSummary.Annotations = clusterProfileScope.ClusterProfile.Annotations
 	clusterSummary.Spec.ClusterProfileSpec = clusterProfileScope.ClusterProfile.Spec
+	clusterSummary.Spec.ClusterType = getClusterType(cluster)
+	clusterSummary.Labels = clusterProfileScope.ClusterProfile.Labels
+	addLabel(clusterSummary, ClusterProfileLabelName, clusterProfileScope.Name())
+	addLabel(clusterSummary, ClusterLabelNamespace, cluster.Namespace)
+	addLabel(clusterSummary, ClusterLabelName, cluster.Name)
+
 	return r.Update(ctx, clusterSummary)
 }
 

--- a/controllers/clusterprofile_controller_test.go
+++ b/controllers/clusterprofile_controller_test.go
@@ -502,7 +502,9 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 		}
 
 		err = controllers.UpdateClusterSummary(reconciler, context.TODO(),
-			clusterProfileScope, &corev1.ObjectReference{Namespace: matchingCluster.Namespace, Name: matchingCluster.Name})
+			clusterProfileScope, &corev1.ObjectReference{
+				Namespace: matchingCluster.Namespace, Name: matchingCluster.Name,
+				Kind: clusterKind, APIVersion: clusterv1.GroupVersion.String()})
 		Expect(err).To(BeNil())
 
 		clusterSummaryList := &configv1alpha1.ClusterSummaryList{}

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -749,14 +749,11 @@ func (r *ClusterSummaryReconciler) canRemoveFinalizer(ctx context.Context,
 func (r *ClusterSummaryReconciler) removeResourceSummary(ctx context.Context,
 	clusterSummaryScope *scope.ClusterSummaryScope, logger logr.Logger) error {
 
-	s, err := InitScheme()
-	if err != nil {
-		return err
-	}
-
+	// ResourceSummary is a Sveltos resource deployed in managed clusters.
+	// Such resources are always created, removed using cluster-admin roles.
 	cs := clusterSummaryScope.ClusterSummary
-	remoteClient, err := getKubernetesClient(ctx, r.Client, s, cs.Spec.ClusterNamespace,
-		cs.Spec.ClusterName, cs.Spec.ClusterType, logger)
+	remoteClient, err := getKubernetesClient(ctx, r.Client, cs.Spec.ClusterNamespace,
+		cs.Spec.ClusterName, "", cs.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}

--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -204,6 +204,16 @@ func (r *ClusterSummaryReconciler) undeployFeature(ctx context.Context, clusterS
 			r.updateFeatureStatus(clusterSummaryScope, f.id, status, nil, result.Err, logger)
 			return fmt.Errorf("feature is still being removed")
 		}
+
+		// Failure to undeploy because of missing permission is ignored.
+		if apierrors.IsForbidden(result.Err) {
+			logger.V(logs.LogInfo).Info("undeploying failing because of missing permission.")
+			tmpStatus := configv1alpha1.FeatureStatusRemoved
+			status = &tmpStatus
+			r.updateFeatureStatus(clusterSummaryScope, f.id, status, nil, result.Err, logger)
+			return nil
+		}
+
 		r.updateFeatureStatus(clusterSummaryScope, f.id, status, nil, result.Err, logger)
 		if *status == configv1alpha1.FeatureStatusRemoved {
 			return nil

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -64,6 +64,7 @@ var (
 	DeployContentOfConfigMap     = deployContentOfConfigMap
 	DeployContentOfSecret        = deployContentOfSecret
 	DeployContent                = deployContent
+	GetClusterSummaryAdmin       = getClusterSummaryAdmin
 	AddAnnotation                = addAnnotation
 	ComputePolicyHash            = computePolicyHash
 	GetPolicyInfo                = getPolicyInfo

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -105,7 +105,12 @@ func deployHelmCharts(ctx context.Context, c client.Client,
 		}
 	}
 
-	kubeconfigContent, err := getSecretData(ctx, c, clusterNamespace, clusterName, clusterSummary.Spec.ClusterType, logger)
+	logger = logger.WithValues("cluster", fmt.Sprintf("%s/%s", clusterNamespace, clusterName))
+	logger = logger.WithValues("clusterSummary", clusterSummary.Name)
+	logger = logger.WithValues("admin", getClusterSummaryAdmin(clusterSummary))
+
+	kubeconfigContent, err := getSecretData(ctx, c, clusterNamespace, clusterName, getClusterSummaryAdmin(clusterSummary),
+		clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}
@@ -149,7 +154,12 @@ func undeployHelmCharts(ctx context.Context, c client.Client,
 		return err
 	}
 
-	kubeconfigContent, err := getSecretData(ctx, c, clusterNamespace, clusterName, clusterSummary.Spec.ClusterType, logger)
+	logger = logger.WithValues("cluster", fmt.Sprintf("%s/%s", clusterNamespace, clusterName))
+	logger = logger.WithValues("clusterSummary", clusterSummary.Name)
+	logger = logger.WithValues("admin", getClusterSummaryAdmin(clusterSummary))
+
+	kubeconfigContent, err := getSecretData(ctx, c, clusterNamespace, clusterName, getClusterSummaryAdmin(clusterSummary),
+		clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -49,6 +49,10 @@ func deployResources(ctx context.Context, c client.Client,
 		return err
 	}
 
+	logger = logger.WithValues("cluster", fmt.Sprintf("%s/%s", clusterNamespace, clusterName))
+	logger = logger.WithValues("clusterSummary", clusterSummary.Name)
+	logger = logger.WithValues("admin", getClusterSummaryAdmin(clusterSummary))
+
 	if clusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeContinuousWithDriftDetection {
 		// Deploy drift detection manager first. Have manager up by the time resourcesummary is created
 		err = deployDriftDetectionManagerInCluster(ctx, c, clusterNamespace, clusterName, applicant,
@@ -58,24 +62,16 @@ func deployResources(ctx context.Context, c client.Client,
 		}
 	}
 
-	remoteRestConfig, err := getKubernetesRestConfig(ctx, c, clusterNamespace, clusterName, clusterSummary.Spec.ClusterType, logger)
+	remoteRestConfig, err := getKubernetesRestConfig(ctx, c, clusterNamespace, clusterName, getClusterSummaryAdmin(clusterSummary),
+		clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}
-
-	logger = logger.WithValues("clustersummary", clusterSummary.Name)
 
 	currentPolicies := make(map[string]configv1alpha1.Resource, 0)
-	refs := featureHandler.getRefs(clusterSummary)
-
-	var referencedObjects []client.Object
-	referencedObjects, err = collectReferencedObjects(ctx, c, refs, logger)
-	if err != nil {
-		return err
-	}
 
 	var resourceReports []configv1alpha1.ResourceReport
-	resourceReports, err = deployReferencedObjects(ctx, c, remoteRestConfig, referencedObjects, clusterSummary, logger)
+	resourceReports, err = deployReferencedObjects(ctx, c, remoteRestConfig, clusterSummary, featureHandler, logger)
 	if err != nil {
 		return err
 	}
@@ -134,27 +130,26 @@ func undeployResources(ctx context.Context, c client.Client,
 	o deployer.Options, logger logr.Logger) error {
 
 	// Get ClusterSummary that requested this
-	clusterSummary := &configv1alpha1.ClusterSummary{}
-	if err := c.Get(ctx, types.NamespacedName{Namespace: clusterNamespace, Name: applicant}, clusterSummary); err != nil {
+	clusterSummary, err := configv1alpha1.GetClusterSummary(ctx, c, clusterNamespace, applicant)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
 
-	logger = logger.WithValues("clustersummary", clusterSummary.Name)
+	logger = logger.WithValues("cluster", fmt.Sprintf("%s/%s", clusterNamespace, clusterName))
+	logger = logger.WithValues("clusterSummary", clusterSummary.Name)
+	logger = logger.WithValues("admin", getClusterSummaryAdmin(clusterSummary))
 
-	s, err := InitScheme()
+	remoteClient, err := getKubernetesClient(ctx, c, clusterNamespace, clusterName, getClusterSummaryAdmin(clusterSummary),
+		clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}
 
-	remoteClient, err := getKubernetesClient(ctx, c, s, clusterNamespace, clusterName, clusterSummary.Spec.ClusterType, logger)
-	if err != nil {
-		return err
-	}
-
-	remoteRestConfig, err := getKubernetesRestConfig(ctx, c, clusterNamespace, clusterName, clusterSummary.Spec.ClusterType, logger)
+	remoteRestConfig, err := getKubernetesRestConfig(ctx, c, clusterNamespace, clusterName, getClusterSummaryAdmin(clusterSummary),
+		clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return err
 	}

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -311,6 +311,16 @@ func getPolicyInfo(policy *configv1alpha1.Resource) string {
 		policy.Name)
 }
 
+// getClusterSummaryAdmin returns the name of the admin that created the ClusterProfile
+// instance owing this ClusterProfile instance
+func getClusterSummaryAdmin(clusterSummary *configv1alpha1.ClusterSummary) string {
+	if clusterSummary.Labels == nil {
+		return ""
+	}
+
+	return clusterSummary.Labels[configv1alpha1.AdminLabel]
+}
+
 // getClusterSummaryAndClusterClient gets ClusterSummary and the client to access the associated
 // CAPI/Sveltos Cluster.
 // Returns an err if ClusterSummary or associated CAPI Cluster are marked for deletion, or if an
@@ -343,13 +353,8 @@ func getClusterSummaryAndClusterClient(ctx context.Context, clusterNamespace, cl
 		return nil, nil, fmt.Errorf("cluster is marked for deletion")
 	}
 
-	s, err := InitScheme()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	clusterClient, err := getKubernetesClient(ctx, c, s, clusterSummary.Spec.ClusterNamespace,
-		clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
+	clusterClient, err := getKubernetesClient(ctx, c, clusterSummary.Spec.ClusterNamespace,
+		clusterSummary.Spec.ClusterName, getClusterSummaryAdmin(clusterSummary), clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -389,24 +394,32 @@ func collectReferencedObjects(ctx context.Context, controlClusterClient client.C
 
 // deployReferencedObjects deploys in a CAPI Cluster the policies contained in the Data section of each passed ConfigMap
 func deployReferencedObjects(ctx context.Context, c client.Client, remoteConfig *rest.Config,
-	referencedObject []client.Object, clusterSummary *configv1alpha1.ClusterSummary,
+	clusterSummary *configv1alpha1.ClusterSummary, featureHandler feature,
 	logger logr.Logger) (reports []configv1alpha1.ResourceReport, err error) {
+
+	refs := featureHandler.getRefs(clusterSummary)
+
+	var referencedObjects []client.Object
+	referencedObjects, err = collectReferencedObjects(ctx, c, refs, logger)
+	if err != nil {
+		return nil, err
+	}
 
 	remoteClient, err := client.New(remoteConfig, client.Options{})
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range referencedObject {
+	for i := range referencedObjects {
 		var tmpResourceReports []configv1alpha1.ResourceReport
-		if referencedObject[i].GetObjectKind().GroupVersionKind().Kind == string(libsveltosv1alpha1.ConfigMapReferencedResourceKind) {
-			configMap := referencedObject[i].(*corev1.ConfigMap)
+		if referencedObjects[i].GetObjectKind().GroupVersionKind().Kind == string(libsveltosv1alpha1.ConfigMapReferencedResourceKind) {
+			configMap := referencedObjects[i].(*corev1.ConfigMap)
 			l := logger.WithValues("configMapNamespace", configMap.Namespace, "configMapName", configMap.Name)
 			l.V(logs.LogDebug).Info("deploying ConfigMap content")
 			tmpResourceReports, err =
 				deployContentOfConfigMap(ctx, remoteConfig, c, remoteClient, configMap, clusterSummary, l)
 		} else {
-			secret := referencedObject[i].(*corev1.Secret)
+			secret := referencedObjects[i].(*corev1.Secret)
 			l := logger.WithValues("secretNamespace", secret.Namespace, "secretName", secret.Name)
 			l.V(logs.LogDebug).Info("deploying Secret content")
 			tmpResourceReports, err =

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -149,6 +149,13 @@ var _ = Describe("HandlersUtils", func() {
 		deleteResources(namespace, clusterProfile, clusterSummary)
 	})
 
+	It("getClusterSummaryAdmin returns the admin for a given ClusterSummary", func() {
+		Expect(controllers.GetClusterSummaryAdmin(clusterSummary)).To(BeEmpty())
+		admin := randomString()
+		clusterSummary.Labels[configv1alpha1.AdminLabel] = admin
+		Expect(controllers.GetClusterSummaryAdmin(clusterSummary)).To(Equal(admin))
+	})
+
 	It("addClusterSummaryLabel adds label with clusterSummary name", func() {
 		role := &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -77,13 +77,9 @@ func collectResourceSummariesFromCluster(ctx context.Context, c client.Client,
 		return nil
 	}
 
-	scheme, err := InitScheme()
-	if err != nil {
-		return err
-	}
-
+	// Use cluster-admin role to collect Sveltos resources from managed clusters
 	var remoteClient client.Client
-	remoteClient, err = getKubernetesClient(ctx, c, scheme, cluster.Namespace, cluster.Name, getClusterType(clusterRef), logger)
+	remoteClient, err = getKubernetesClient(ctx, c, cluster.Namespace, cluster.Name, "", getClusterType(clusterRef), logger)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3
+	github.com/projectsveltos/libsveltos v0.3.1-0.20230129021247-6caa90913d47
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -790,8 +790,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
-github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3 h1:6Yv0aM8Qs1ksImBGA3C9XpPLtNXEzHbUznSAUr18N3A=
-github.com/projectsveltos/libsveltos v0.3.1-0.20230125005717-27e468b0f0d3/go.mod h1:smYCt3DQSZpQqsaoM2mJAIP6RAMXcxw5Af0mzkncCs4=
+github.com/projectsveltos/libsveltos v0.3.1-0.20230129021247-6caa90913d47 h1:5fh0jEZVFbxV5BXXqLVdJ8E0llfx56W90ivTNJJQ6uI=
+github.com/projectsveltos/libsveltos v0.3.1-0.20230129021247-6caa90913d47/go.mod h1:smYCt3DQSZpQqsaoM2mJAIP6RAMXcxw5Af0mzkncCs4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=


### PR DESCRIPTION
ClusterProfiles created by a tenant admin, contain the label projectsveltos.io/admin-name.

Such labels is copied over to ClusterSummary.

When Sveltos finds a ClusterSummary with such labels, instead of using cluster-admin role to deploy add-ons, fetches the Kubeconfig assiciated to tenant admin (such Kubeconfig is created by access-managed while processing RoleRequests).