### PR TITLE
build: Parametrize kind cluster yaml filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ KIND_CONFIG ?= kind-cluster.yaml
 CONTROL_CLUSTER_NAME ?= sveltos-management
 WORKLOAD_CLUSTER_NAME ?= sveltos-management-workload
 TIMEOUT ?= 10m
-KIND_CLUSTER_YAML ?= test/sveltos-management-workload.yaml
+KIND_CLUSTER_YAML ?= test/$(WORKLOAD_CLUSTER_NAME).yaml
 NUM_NODES ?= 5
 
 .PHONY: test


### PR DESCRIPTION
The file name used for the generated kind workload cluster must reflect the cluster name that was overridden using `WORKLOAD_CLUSTER_NAME`.