### PR TITLE
ClusterProfile first, Cluster later: no add-ons deployed

### DIFF
--- a/controllers/clusterprofile_controller.go
+++ b/controllers/clusterprofile_controller.go
@@ -62,6 +62,14 @@ type ClusterProfileReconciler struct {
 	// key: ClusterProfile; value ClusterProfile Selector
 	ClusterProfiles map[corev1.ObjectReference]libsveltosv1alpha1.Selector
 
+	// For each cluster contains current labels
+	// This is needed in following scenario:
+	// - ClusterProfile is created
+	// - Cluster is created with labels matching ClusterProfile
+	// - When first control plane machine in such cluster becomes available
+	// we need Cluster labels to know which ClusterProfile to reconcile
+	ClusterLabels map[corev1.ObjectReference]map[string]string
+
 	// Reason for the two maps:
 	// ClusterProfile, via ClusterSelector, matches Sveltos/CAPI Clusters based on Cluster labels.
 	// When a Sveltos/CAPI Cluster labels change, one or more ClusterProfile needs to be reconciled.

--- a/controllers/clusterprofile_controller_test.go
+++ b/controllers/clusterprofile_controller_test.go
@@ -105,6 +105,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -155,6 +156,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -238,6 +240,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -292,6 +295,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -367,6 +371,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -412,6 +417,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -498,6 +504,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -577,6 +584,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -644,6 +652,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -678,6 +687,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -733,6 +743,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -824,6 +835,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -870,6 +882,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -920,6 +933,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -973,6 +987,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -1032,6 +1047,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 

--- a/controllers/clusterprofile_transformations_test.go
+++ b/controllers/clusterprofile_transformations_test.go
@@ -87,6 +87,7 @@ var _ = Describe("ClusterProfileReconciler map functions", func() {
 			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 			Mux:               sync.Mutex{},
 		}
 
@@ -149,5 +150,66 @@ var _ = Describe("ClusterProfileReconciler map functions", func() {
 
 		requests = controllers.RequeueClusterProfileForCluster(reconciler, cluster)
 		Expect(requests).To(HaveLen(0))
+	})
+
+	It("RequeueClusterProfileForMachine returns correct ClusterProfiles for a CAPI machine", func() {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      upstreamClusterNamePrefix + randomString(),
+				Namespace: namespace,
+				Labels: map[string]string{
+					"env": "production",
+				},
+			},
+		}
+
+		cpMachine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name + randomString(),
+				Labels: map[string]string{
+					clusterv1.ClusterLabelName:             cluster.Name,
+					clusterv1.MachineControlPlaneLabelName: "ok",
+				},
+			},
+		}
+
+		clusterProfile := &configv1alpha1.ClusterProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterProfileNamePrefix + randomString(),
+			},
+			Spec: configv1alpha1.ClusterProfileSpec{
+				ClusterSelector: libsveltosv1alpha1.Selector("env=production"),
+			},
+		}
+
+		Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
+		Expect(addTypeInformationToObject(scheme, cpMachine)).To(Succeed())
+		Expect(addTypeInformationToObject(scheme, clusterProfile)).To(Succeed())
+
+		// In this scenario:
+		// - ClusterProfile added first
+		// - Cluster matching ClusterProfile added later
+		// - First controlplane Machine in Cluster is ready
+		// The only information Sveltos has are:
+		// - Cluster's labels (stored in ClusterLabels map)
+		// - ClusterProfile's selector (stored in ClusterProfiles maps)
+		// RequeueClusterProfileForMachine gets cluster from machine and using ClusterLabels
+		// and ClusterProfiles maps finds the ClusterProfiles that need to be reconciled
+
+		apiVersion, kind := cluster.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+		clusterProfileReconciler := getClusterProfileReconciler(testEnv.Client)
+
+		clusterInfo := corev1.ObjectReference{APIVersion: apiVersion, Kind: kind,
+			Namespace: cluster.GetNamespace(), Name: cluster.GetName()}
+		clusterProfileReconciler.ClusterLabels[clusterInfo] = cluster.Labels
+
+		apiVersion, kind = clusterProfile.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+		clusterProfileInfo := corev1.ObjectReference{APIVersion: apiVersion, Kind: kind, Name: clusterProfile.GetName()}
+		clusterProfileReconciler.ClusterProfiles[clusterProfileInfo] = clusterProfile.Spec.ClusterSelector
+
+		clusterProfileList := controllers.RequeueClusterProfileForMachine(clusterProfileReconciler,
+			cpMachine)
+		Expect(len(clusterProfileList)).To(Equal(1))
 	})
 })

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -211,7 +211,7 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 	err = r.removeResourceSummary(ctx, clusterSummaryScope, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Info("failed to remove ResourceSummary.")
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
 	}
 
 	err = r.undeploy(ctx, clusterSummaryScope, logger)

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -133,6 +133,7 @@ func getClusterProfileReconciler(c client.Client) *controllers.ClusterProfileRec
 		ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+		ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
 		Mux:               sync.Mutex{},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func main() {
 		ClusterMap:           make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterProfileMap:    make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ClusterProfiles:      make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+		ClusterLabels:        make(map[corev1.ObjectReference]map[string]string),
 		Mux:                  sync.Mutex{},
 		ConcurrentReconciles: concurrentReconciles,
 	}


### PR DESCRIPTION
If ClusterProfile is created first and CAPI Cluster later, then add-ons are not deployed.

In above sequence, Sveltos never recognizes Cluster is a match for the ClusterProfile instance.
Problem is that when Cluster is created, ClusterProfile is reconciled. But at that time, no machine is available yet. So reconciliation does nothing.
Later on when first machine in the cluster becomes ready, Sveltos does not have necessary information to understand cluster is a now a match.

This PR fixes above bug.
A new map is added to ClusterProfileReconciler. This map contains per Cluster instance, their current labels.

When machine in a cluster gets ready, requeueClusterProfileForMachine transformation function is invoked.
Here Sveltos, using the new map, gets the Cluster's labels. Walks all existing ClusterProfiles, and requeues for reconciliations the ones for which Cluster is a match.

Fixes #143 