### PR TITLE
Expose labels set on ClusterSummary

### DIFF
--- a/api/v1alpha1/clusterprofile_types.go
+++ b/api/v1alpha1/clusterprofile_types.go
@@ -35,6 +35,20 @@ const (
 	AdminLabel = "projectsveltos.io/admin-name"
 )
 
+const (
+	// ClusterNameLabel is the label set on:
+	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
+	ClusterNameLabel = "projectsveltos.io/cluster-name"
+
+	// ClusterTypeLabel is the label set on:
+	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
+	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
+	ClusterTypeLabel = "projectsveltos.io/cluster-type"
+)
+
 type DryRunReconciliationError struct{}
 
 func (m *DryRunReconciliationError) Error() string {

--- a/controllers/clusterprofile_controller.go
+++ b/controllers/clusterprofile_controller.go
@@ -460,9 +460,9 @@ func (r *ClusterProfileReconciler) createClusterReport(ctx context.Context, clus
 			Namespace: cluster.Namespace,
 			Name:      getClusterReportName(clusterProfile.Name, cluster.Name, clusterType),
 			Labels: map[string]string{
-				ClusterProfileLabelName: clusterProfile.Name,
-				ClusterLabelName:        cluster.Name,
-				ClusterTypeLabelName:    string(getClusterType(cluster)),
+				ClusterProfileLabelName:         clusterProfile.Name,
+				configv1alpha1.ClusterNameLabel: cluster.Name,
+				configv1alpha1.ClusterTypeLabel: string(getClusterType(cluster)),
 			},
 		},
 		Spec: configv1alpha1.ClusterReportSpec{
@@ -529,7 +529,7 @@ func (r *ClusterProfileReconciler) updateClusterSummaries(ctx context.Context, c
 		// If a Cluster exists and it is a match, ClusterSummary is created (and ClusterSummary.Spec kept in sync if mode is
 		// continuous).
 		// ClusterSummary won't program cluster in paused state.
-		_, err = getClusterSummary(ctx, r.Client, clusterProfileScope.Name(), cluster.Namespace, cluster.Name)
+		_, err = getClusterSummary(ctx, r.Client, clusterProfileScope.Name(), cluster.Namespace, cluster.Name, getClusterType(&cluster))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				err = r.createClusterSummary(ctx, clusterProfileScope, &cluster)
@@ -754,9 +754,7 @@ func (r *ClusterProfileReconciler) createClusterSummary(ctx context.Context, clu
 
 	clusterSummary.Spec.ClusterType = getClusterType(cluster)
 	clusterSummary.Labels = clusterProfileScope.ClusterProfile.Labels
-	addLabel(clusterSummary, ClusterProfileLabelName, clusterProfileScope.Name())
-	addLabel(clusterSummary, ClusterLabelNamespace, cluster.Namespace)
-	addLabel(clusterSummary, ClusterLabelName, cluster.Name)
+	r.addClusterSummaryLabels(clusterSummary, clusterProfileScope, cluster)
 
 	return r.Create(ctx, clusterSummary)
 }
@@ -770,7 +768,7 @@ func (r *ClusterProfileReconciler) updateClusterSummary(ctx context.Context, clu
 		return nil
 	}
 
-	clusterSummary, err := getClusterSummary(ctx, r.Client, clusterProfileScope.Name(), cluster.Namespace, cluster.Name)
+	clusterSummary, err := getClusterSummary(ctx, r.Client, clusterProfileScope.Name(), cluster.Namespace, cluster.Name, getClusterType(cluster))
 	if err != nil {
 		return err
 	}
@@ -784,12 +782,21 @@ func (r *ClusterProfileReconciler) updateClusterSummary(ctx context.Context, clu
 	clusterSummary.Annotations = clusterProfileScope.ClusterProfile.Annotations
 	clusterSummary.Spec.ClusterProfileSpec = clusterProfileScope.ClusterProfile.Spec
 	clusterSummary.Spec.ClusterType = getClusterType(cluster)
-	clusterSummary.Labels = clusterProfileScope.ClusterProfile.Labels
-	addLabel(clusterSummary, ClusterProfileLabelName, clusterProfileScope.Name())
-	addLabel(clusterSummary, ClusterLabelNamespace, cluster.Namespace)
-	addLabel(clusterSummary, ClusterLabelName, cluster.Name)
+	r.addClusterSummaryLabels(clusterSummary, clusterProfileScope, cluster)
 
 	return r.Update(ctx, clusterSummary)
+}
+
+func (r *ClusterProfileReconciler) addClusterSummaryLabels(clusterSummary *configv1alpha1.ClusterSummary, clusterProfileScope *scope.ClusterProfileScope,
+	cluster *corev1.ObjectReference) {
+
+	addLabel(clusterSummary, ClusterProfileLabelName, clusterProfileScope.Name())
+	addLabel(clusterSummary, configv1alpha1.ClusterNameLabel, cluster.Name)
+	if cluster.APIVersion == libsveltosv1alpha1.GroupVersion.String() {
+		addLabel(clusterSummary, configv1alpha1.ClusterTypeLabel, string(libsveltosv1alpha1.ClusterTypeSveltos))
+	} else {
+		addLabel(clusterSummary, configv1alpha1.ClusterTypeLabel, string(libsveltosv1alpha1.ClusterTypeCapi))
+	}
 }
 
 // deleteClusterSummary deletes ClusterSummary given a ClusterProfile and a matching Sveltos/CAPI Cluster
@@ -848,8 +855,8 @@ func (r *ClusterProfileReconciler) createClusterConfiguration(ctx context.Contex
 			Namespace: cluster.Namespace,
 			Name:      getClusterConfigurationName(cluster.Name, getClusterType(cluster)),
 			Labels: map[string]string{
-				ClusterLabelName:     cluster.Name,
-				ClusterTypeLabelName: string(getClusterType(cluster)),
+				configv1alpha1.ClusterNameLabel: cluster.Name,
+				configv1alpha1.ClusterTypeLabel: string(getClusterType(cluster)),
 			},
 		},
 	}

--- a/controllers/clusterprofile_controller_test.go
+++ b/controllers/clusterprofile_controller_test.go
@@ -444,16 +444,24 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 	})
 
 	It("UpdateClusterSummary updates ClusterSummary with proper fields when ClusterProfile syncmode set to continuous", func() {
-		clusterSummaryName := controllers.GetClusterSummaryName(clusterProfile.Name, matchingCluster.Name, false)
+		sveltosCluster := &libsveltosv1alpha1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+				Labels:    matchingCluster.Labels,
+			},
+		}
+
+		clusterSummaryName := controllers.GetClusterSummaryName(sveltosCluster.Name, sveltosCluster.Name, false)
 		clusterSummary := &configv1alpha1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSummaryName,
-				Namespace: matchingCluster.Namespace,
+				Namespace: sveltosCluster.Namespace,
 			},
 			Spec: configv1alpha1.ClusterSummarySpec{
-				ClusterNamespace: matchingCluster.Namespace,
-				ClusterName:      matchingCluster.Name,
-				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
+				ClusterNamespace: sveltosCluster.Namespace,
+				ClusterName:      sveltosCluster.Name,
+				ClusterType:      libsveltosv1alpha1.ClusterTypeSveltos,
 				ClusterProfileSpec: configv1alpha1.ClusterProfileSpec{
 					SyncMode: configv1alpha1.SyncModeOneTime,
 					PolicyRefs: []libsveltosv1alpha1.PolicyRef{
@@ -466,7 +474,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 				},
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Namespace, matchingCluster.Name)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, sveltosCluster.Name, libsveltosv1alpha1.ClusterTypeSveltos)
 
 		clusterProfile.Spec.SyncMode = configv1alpha1.SyncModeContinuous
 		clusterProfile.Spec.PolicyRefs = []libsveltosv1alpha1.PolicyRef{
@@ -484,7 +492,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 
 		initObjects := []client.Object{
 			clusterProfile,
-			matchingCluster,
+			sveltosCluster,
 			clusterSummary,
 		}
 
@@ -510,15 +518,15 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 
 		err = controllers.UpdateClusterSummary(reconciler, context.TODO(),
 			clusterProfileScope, &corev1.ObjectReference{
-				Namespace: matchingCluster.Namespace, Name: matchingCluster.Name,
-				Kind: clusterKind, APIVersion: clusterv1.GroupVersion.String()})
+				Namespace: sveltosCluster.Namespace, Name: sveltosCluster.Name,
+				Kind: libsveltosv1alpha1.SveltosClusterKind, APIVersion: libsveltosv1alpha1.GroupVersion.String()})
 		Expect(err).To(BeNil())
 
 		clusterSummaryList := &configv1alpha1.ClusterSummaryList{}
 		Expect(c.List(context.TODO(), clusterSummaryList)).To(BeNil())
 		Expect(len(clusterSummaryList.Items)).To(Equal(1))
-		Expect(clusterSummaryList.Items[0].Spec.ClusterName).To(Equal(matchingCluster.Name))
-		Expect(clusterSummaryList.Items[0].Spec.ClusterNamespace).To(Equal(matchingCluster.Namespace))
+		Expect(clusterSummaryList.Items[0].Spec.ClusterName).To(Equal(sveltosCluster.Name))
+		Expect(clusterSummaryList.Items[0].Spec.ClusterNamespace).To(Equal(sveltosCluster.Namespace))
 		Expect(reflect.DeepEqual(clusterSummaryList.Items[0].Spec.ClusterProfileSpec, clusterProfile.Spec)).To(BeTrue())
 	})
 
@@ -550,7 +558,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 				ClusterType:        libsveltosv1alpha1.ClusterTypeCapi,
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Namespace, matchingCluster.Name)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 
 		initObjects := []client.Object{
 			clusterProfile,
@@ -636,7 +644,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 				ClusterType:        libsveltosv1alpha1.ClusterTypeCapi,
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Namespace, matchingCluster.Name)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 
 		initObjects := []client.Object{
 			clusterProfile,
@@ -817,7 +825,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 				},
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Namespace, matchingCluster.Name)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, matchingCluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 
 		initObjects := []client.Object{
 			clusterProfile,

--- a/controllers/clustersummary_deployer_test.go
+++ b/controllers/clustersummary_deployer_test.go
@@ -63,7 +63,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, namespace, clusterName)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, clusterName, libsveltosv1alpha1.ClusterTypeCapi)
 
 		cluster = &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/labels.go
+++ b/controllers/labels.go
@@ -29,22 +29,6 @@ const (
 	// by a ClusterProfile instance
 	ClusterProfileLabelName = "projectsveltos.io/cluster-profile-name"
 
-	// clusterLabelNamespace is the label set on ClusterSummary instances created
-	// by a ClusterProfile instance for a given cluster
-	ClusterLabelNamespace = "projectsveltos.io/cluster-namespace"
-
-	// clusterLabelName is the label set on:
-	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
-	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
-	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
-	ClusterLabelName = "projectsveltos.io/cluster-name"
-
-	// ClusterTypeLabelName is the label set on:
-	// - ClusterSummary instances created by a ClusterProfile instance for a given cluster;
-	// - ClusterConfiguration instances created by a ClusterProfile instance for a given cluster;
-	// - ClusterReport instances created by a ClusterProfile instance for a given cluster;
-	ClusterTypeLabelName = "projectsveltos.io/cluster-type"
-
 	// PolicyTemplate is the annotation that must be set on a policy when the
 	// policy is a template and needs variable sustitution.
 	PolicyTemplate = "projectsveltos.io/template"

--- a/controllers/suite_helpers_test.go
+++ b/controllers/suite_helpers_test.go
@@ -146,14 +146,16 @@ func randomString() string {
 	return util.RandomString(length)
 }
 
-func addLabelsToClusterSummary(clusterSummary *configv1alpha1.ClusterSummary, clusterProfileName, clusterNamespace, clusterName string) {
+func addLabelsToClusterSummary(clusterSummary *configv1alpha1.ClusterSummary, clusterProfileName, clusterName string,
+	clusterType libsveltosv1alpha1.ClusterType) {
+
 	labels := clusterSummary.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 	labels[controllers.ClusterProfileLabelName] = clusterProfileName
-	labels[controllers.ClusterLabelNamespace] = clusterNamespace
-	labels[controllers.ClusterLabelName] = clusterName
+	labels[configv1alpha1.ClusterTypeLabel] = string(clusterType)
+	labels[configv1alpha1.ClusterNameLabel] = clusterName
 
 	clusterSummary.Labels = labels
 }
@@ -227,7 +229,7 @@ func prepareForDeployment(clusterProfile *configv1alpha1.ClusterProfile,
 	cluster *clusterv1.Cluster) {
 
 	By("Add proper labels to ClusterSummary")
-	addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, cluster.Namespace, cluster.Name)
+	addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 
 	Expect(addTypeInformationToObject(testEnv.Scheme(), clusterProfile)).To(Succeed())
 	Expect(addTypeInformationToObject(testEnv.Scheme(), clusterSummary)).To(Succeed())

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -75,14 +75,15 @@ func GetClusterSummaryName(clusterProfileName, clusterName string, isSveltosClus
 // getClusterSummary returns the ClusterSummary instance created by a specific ClusterProfile for a specific
 // CAPI Cluster
 func getClusterSummary(ctx context.Context, c client.Client,
-	clusterProfileName, clusterNamespace, clusterName string) (*configv1alpha1.ClusterSummary, error) {
+	clusterProfileName, clusterNamespace, clusterName string,
+	clusterType libsveltosv1alpha1.ClusterType) (*configv1alpha1.ClusterSummary, error) {
 
 	listOptions := []client.ListOption{
 		client.InNamespace(clusterNamespace),
 		client.MatchingLabels{
-			ClusterProfileLabelName: clusterProfileName,
-			ClusterLabelNamespace:   clusterNamespace,
-			ClusterLabelName:        clusterName,
+			ClusterProfileLabelName:         clusterProfileName,
+			configv1alpha1.ClusterNameLabel: clusterName,
+			configv1alpha1.ClusterTypeLabel: string(clusterType),
 		},
 	}
 

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -172,7 +172,7 @@ var _ = Describe("getClusterProfileOwner ", func() {
 				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
 			},
 		}
-		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, cluster.Namespace, cluster.Name)
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, cluster.Name, libsveltosv1alpha1.ClusterTypeCapi)
 	})
 
 	It("getClusterProfileOwner returns ClusterProfile owner", func() {
@@ -255,7 +255,8 @@ var _ = Describe("getClusterProfileOwner ", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-		currentClusterSummary, err := controllers.GetClusterSummary(context.TODO(), c, clusterProfile.Name, cluster.Namespace, cluster.Name)
+		currentClusterSummary, err := controllers.GetClusterSummary(context.TODO(), c, clusterProfile.Name, cluster.Namespace, cluster.Name,
+			libsveltosv1alpha1.ClusterTypeCapi)
 		Expect(err).To(BeNil())
 		Expect(currentClusterSummary).ToNot(BeNil())
 		Expect(currentClusterSummary.Name).To(Equal(clusterSummary.Name))

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -177,8 +177,8 @@ func getClusterSummary(ctx context.Context,
 		client.InNamespace(clusterNamespace),
 		client.MatchingLabels{
 			controllers.ClusterProfileLabelName: clusterProfileName,
-			controllers.ClusterLabelNamespace:   clusterNamespace,
-			controllers.ClusterLabelName:        clusterName,
+			configv1alpha1.ClusterNameLabel:     clusterName,
+			configv1alpha1.ClusterTypeLabel:     string(libsveltosv1alpha1.ClusterTypeCapi),
 		},
 	}
 


### PR DESCRIPTION
When ClusterProfile creates a ClusterSummary following labels are added on ClusterSummary instance:
1. ClusterNameLabel containing the name of the Cluster, the ClusterSummary instance has been created for;
2. ClusterTypeLabel containing the type of the Cluster, the ClusterSummary instance has been created for.

Exposing this information now as other Sveltos microservices will need to find all ClusterSummaries for a given Cluster. For instance, healthcheck-manager will need to find all ClusterSummaries for a given Cluster in order to evaluate when all add-ons are deployed.